### PR TITLE
Adding hierarchy for the Destination sitemap section.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@
 * Fix - Fix for 'Content wider than screen' Google Console issue.
 * Fix - Fixed the undefined notice when using and array of post types with WP_Query
 * Fix - Moving the description text on main Archive pages above the filters.
+* Dev - Adding hierarchy for the Destination sitemap section.
 
 ### 1.3.0 - 2 October 2019
 * Fix - Fixed the Post Type enquiry dropdown.

--- a/includes/template-tags/general.php
+++ b/includes/template-tags/general.php
@@ -659,3 +659,24 @@ if ( ! function_exists( 'lsx_to_gallery' ) ) {
 		}
 	}
 }
+
+/* ==================  SITEMAP  ================== */
+
+if ( ! function_exists( 'to_sitemap_loops' ) ) {
+	/**
+	 * Add Hierarchy for Destinations Sitemap.
+	 *
+	 * @param [type] $sitemap_loops
+	 * @return void
+	 */
+	function to_sitemap_loops( $sitemap_loops ) {
+		$sitemap_loops['destination'] = array(
+			'type'      => 'post_type',
+			'label'     => __( 'Destinations', 'lsx' ),
+			'heirarchy' => true,
+		);
+
+		return $sitemap_loops;
+	}
+	add_filter( 'lsx_sitemap_loops_list', 'to_sitemap_loops', 1 );
+}


### PR DESCRIPTION
This branch is to enhance the sitemap with hierarchy for Destinations on the sitemap, see issue: https://github.com/lightspeeddevelopment/tour-operator/issues/75