### PR TITLE
Sanitizing widget options - Add/45

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Fixing the departure day not using the tours featured image.
 * Dev - Added in a filter 'lsx_to_maps_tour_connections' to allow 3rd party filters of the tour itinerary map connections.
 * Dev - Sanitizing widget fields.
+* Fix - Fix output escaping issues.
 
 ### 1.4.0 - 19 December 2019
 * Dev - Added in a parameter to lsx_to_enquire_modal() to allow a form_id to be specified

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Adding in the 'lsx_to_get_tour_itinerary_ids' to fix the order of the map IDS
 * Fix - Fixing the departure day not using the tours featured image.
 * Dev - Added in a filter 'lsx_to_maps_tour_connections' to allow 3rd party filters of the tour itinerary map connections.
+* Dev - Sanitizing widget fields.
 
 ### 1.4.0 - 19 December 2019
 * Dev - Added in a parameter to lsx_to_enquire_modal() to allow a form_id to be specified

--- a/includes/classes/legacy/class-admin.php
+++ b/includes/classes/legacy/class-admin.php
@@ -288,7 +288,7 @@ class Admin extends Tour_Operator {
 			$image_preview = wp_get_attachment_image_src( $value, 'thumbnail' );
 
 			if ( is_array( $image_preview ) ) {
-				$image_preview = '<img src="' . $image_preview[0] . '" width="' . $image_preview[1] . '" height="' . $image_preview[2] . '" class="alignnone size-thumbnail wp-image-' . $value . '" />';
+				$image_preview = '<img src="' . esc_url( $image_preview[0] ) . '" width="' . $image_preview[1] . '" height="' . $image_preview[2] . '" class="alignnone size-thumbnail d wp-image-' . $value . '" />';
 			}
 		} else {
 			$image_preview = false;

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -473,7 +473,7 @@ class Frontend extends Tour_Operator {
 	 * @return    string $content
 	 */
 	public function modify_read_more_link( $content ) {
-		$content = str_replace( '<span id="more-' . get_the_ID() . '"></span>', '<a class="lsx-to-more-link more-link" data-collapsed="true" href="' . get_permalink() . '">' . esc_html__( 'Read More', 'tour-operator' ) . '</a>', $content );
+		$content = str_replace( '<span id="more-' . esc_attr( get_the_ID() ) . '"></span>', '<a class="lsx-to-more-link more-link" data-collapsed="true" href="' . get_permalink() . '">' . esc_html__( 'Read More', 'tour-operator' ) . '</a>', $content );
 
 		return $content;
 	}

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -473,7 +473,7 @@ class Frontend extends Tour_Operator {
 	 * @return    string $content
 	 */
 	public function modify_read_more_link( $content ) {
-		$content = str_replace( '<span id="more-' . esc_attr( get_the_ID() ) . '"></span>', '<a class="lsx-to-more-link more-link" data-collapsed="true" href="' . get_permalink() . '">' . esc_html__( 'Read More', 'tour-operator' ) . '</a>', $content );
+		$content = str_replace( '<span id="more-' . esc_attr( get_the_ID() ) . '"></span>', '<a class="lsx-to-more-link more-link" data-collapsed="true" href="' . esc_url( get_permalink() ) . '">' . esc_html__( 'Read More', 'tour-operator' ) . '</a>', $content );
 
 		return $content;
 	}

--- a/includes/classes/legacy/class-taxonomy-widget.php
+++ b/includes/classes/legacy/class-taxonomy-widget.php
@@ -497,7 +497,8 @@ class Taxonomy_Widget extends \WP_Widget {
 			$this->after_while( $columns, $carousel, $taxonomy, count( $widget_query ) );
 
 			if ( false !== $buttons && false != $link ) {
-				echo wp_kses_post( '<p class="lsx-to-widget-view-all"><span><a href="' . $link . '" class="btn border-btn">' . $button_text . ' <i class="fa fa-angle-right"></i></a></span></p>' );
+				$link = '/' . $taxonomy . 's';
+				echo wp_kses_post( '<p class="lsx-to-widget-view-all"><span><a href="' . esc_url( $link ) . '" class="btn border-btn">' . $button_text . ' <i class="fa fa-angle-right"></i></a></span></p>' );
 			}
 		}
 

--- a/includes/classes/legacy/class-widget.php
+++ b/includes/classes/legacy/class-widget.php
@@ -231,12 +231,11 @@ class Widget extends \WP_Widget {
 	/** @see WP_Widget::update -- do not rename this */
 	function update( $new_instance, $old_instance ) {
 		$instance                        = $old_instance;
-		$range_columns                   = range( 1, 6 );
 		$instance['title']               = esc_html( force_balance_tags( $new_instance['title'] ) );
 		$instance['title_link']          = esc_url_raw( $new_instance['title_link'] );
-		$instance['columns']             = in_array( $new_instance['columns'], $range_columns ) ? $new_instance['columns'] : 3;
-		$instance['orderby']             = sanitize_text_field( $new_instance['orderby'] );
-		$instance['order']               = sanitize_text_field( $new_instance['order'] );
+		$instance['columns']             = in_array( $new_instance['columns'], range( 1, 6 ) ) ? $new_instance['columns'] : 1;
+		$instance['orderby']             = in_array( $new_instance['columns'], range( 1, 7 ) ) ? $new_instance['orderby'] : 1;
+		$instance['order']               = in_array( $new_instance['columns'], range( 1, 2 ) ) ? $new_instance['order'] : 1;
 		$instance['limit']               = wp_kses_post( $new_instance['limit'] );
 		$instance['include']             = wp_kses_post( $new_instance['include'] );
 		$instance['parents_only']        = sanitize_text_field( $new_instance['parents_only'] );
@@ -247,7 +246,7 @@ class Widget extends \WP_Widget {
 		$instance['button_text']         = esc_html( force_balance_tags( $new_instance['button_text'] ) );
 		$instance['carousel']            = sanitize_text_field( $new_instance['carousel'] );
 		$instance['featured']            = sanitize_text_field( $new_instance['featured'] );
-		$instance['post_type']           = sanitize_text_field( $new_instance['post_type'] );
+		$instance['post_type']           = in_array( $new_instance['columns'], range( 1, 8 ) ) ? $new_instance['post_type'] : 1;
 		$instance['class']               = esc_html( $new_instance['class'] );
 		$instance['interval']            = esc_html( $new_instance['interval'] );
 		return $instance;

--- a/includes/classes/legacy/class-widget.php
+++ b/includes/classes/legacy/class-widget.php
@@ -231,24 +231,25 @@ class Widget extends \WP_Widget {
 	/** @see WP_Widget::update -- do not rename this */
 	function update( $new_instance, $old_instance ) {
 		$instance                        = $old_instance;
-		$instance['title']               = wp_kses_post( force_balance_tags( $new_instance['title'] ) );
-		$instance['title_link']          = wp_strip_all_tags( $new_instance['title_link'] );
-		$$instance['columns']            = in_array( $new_instance['columns'], range( 1, 6 ), true ) ? $new_instance['columns'] : 1;
-		$instance['orderby']             = wp_strip_all_tags( $new_instance['orderby'] );
-		$instance['order']               = wp_strip_all_tags( $new_instance['order'] );
-		$instance['limit']               = wp_strip_all_tags( $new_instance['limit'] );
-		$instance['include']             = wp_strip_all_tags( $new_instance['include'] );
-		$instance['parents_only']        = wp_strip_all_tags( $new_instance['parents_only'] );
-		$instance['disable_placeholder'] = wp_strip_all_tags( $new_instance['disable_placeholder'] );
-		$instance['disable_text']        = wp_strip_all_tags( $new_instance['disable_text'] );
-		$instance['disable_view_more']   = wp_strip_all_tags( $new_instance['disable_view_more'] );
-		$instance['buttons']             = wp_strip_all_tags( $new_instance['buttons'] );
-		$instance['button_text']         = $new_instance['button_text'];
-		$instance['carousel']            = wp_strip_all_tags( $new_instance['carousel'] );
-		$instance['featured']            = wp_strip_all_tags( $new_instance['featured'] );
-		$instance['post_type']           = wp_strip_all_tags( $new_instance['post_type'] );
-		$instance['class']               = wp_strip_all_tags( $new_instance['class'] );
-		$instance['interval']            = wp_strip_all_tags( $new_instance['interval'] );
+		$range_columns                   = range( 1, 6 );
+		$instance['title']               = esc_html( force_balance_tags( $new_instance['title'] ) );
+		$instance['title_link']          = esc_url_raw( $new_instance['title_link'] );
+		$instance['columns']             = in_array( $new_instance['columns'], $range_columns ) ? $new_instance['columns'] : 3;
+		$instance['orderby']             = sanitize_text_field( $new_instance['orderby'] );
+		$instance['order']               = sanitize_text_field( $new_instance['order'] );
+		$instance['limit']               = wp_kses_post( $new_instance['limit'] );
+		$instance['include']             = wp_kses_post( $new_instance['include'] );
+		$instance['parents_only']        = sanitize_text_field( $new_instance['parents_only'] );
+		$instance['disable_placeholder'] = sanitize_text_field( $new_instance['disable_placeholder'] );
+		$instance['disable_text']        = sanitize_text_field( $new_instance['disable_text'] );
+		$instance['disable_view_more']   = sanitize_text_field( $new_instance['disable_view_more'] );
+		$instance['buttons']             = sanitize_text_field( $new_instance['buttons'] );
+		$instance['button_text']         = esc_html( force_balance_tags( $new_instance['button_text'] ) );
+		$instance['carousel']            = sanitize_text_field( $new_instance['carousel'] );
+		$instance['featured']            = sanitize_text_field( $new_instance['featured'] );
+		$instance['post_type']           = sanitize_text_field( $new_instance['post_type'] );
+		$instance['class']               = esc_html( $new_instance['class'] );
+		$instance['interval']            = esc_html( $new_instance['interval'] );
 		return $instance;
 	}
 

--- a/includes/classes/legacy/class-widget.php
+++ b/includes/classes/legacy/class-widget.php
@@ -567,7 +567,7 @@ class Widget extends \WP_Widget {
 			$this->after_while( $columns, $carousel, $post_type, $widget_query->post_count );
 
 			if ( false !== $buttons && false !== $link ) {
-				echo wp_kses_post( '<p class="lsx-to-widget-view-all"><span><a href="' . $link . '" class="btn border-btn">' . $button_text . ' <i class="fa fa-angle-right"></i></a></span></p>' );
+				echo wp_kses_post( '<p class="lsx-to-widget-view-all"><span><a href="' . esc_url( $link ) . '" class="btn border-btn">' . $button_text . ' <i class="fa fa-angle-right"></i></a></span></p>' );
 			}
 
 			wp_reset_postdata();

--- a/includes/classes/legacy/class-widget.php
+++ b/includes/classes/legacy/class-widget.php
@@ -233,7 +233,7 @@ class Widget extends \WP_Widget {
 		$instance                        = $old_instance;
 		$instance['title']               = wp_kses_post( force_balance_tags( $new_instance['title'] ) );
 		$instance['title_link']          = wp_strip_all_tags( $new_instance['title_link'] );
-		$instance['columns']             = wp_strip_all_tags( $new_instance['columns'] );
+		$$instance['columns']            = in_array( $new_instance['columns'], range( 1, 6 ), true ) ? $new_instance['columns'] : 1;
 		$instance['orderby']             = wp_strip_all_tags( $new_instance['orderby'] );
 		$instance['order']               = wp_strip_all_tags( $new_instance['order'] );
 		$instance['limit']               = wp_strip_all_tags( $new_instance['limit'] );

--- a/includes/partials/add-ons.php
+++ b/includes/partials/add-ons.php
@@ -111,7 +111,7 @@
 
 			<div class="box box-top-image vehicles">
 				<h3><?php esc_html_e( 'Vehicles', 'tour-operator' ); ?></h3>
-				<p><?php esc_html_e( 'To help convince travellers of their comfort and safety when traveling with you, we’ve created the Vehicles extension. Fill in your fleets’ specs and display your vehicles on connected tours and destinations. With a range of avaiable options such as; type and number of gears, engine type (petrol/diesel), number of seats, vehicle code, and of course images and copy.', 'tour-operator' ); ?></p>
+				<p><?php esc_html_e( 'To help convince travellers of their comfort and safety when traveling with you, we’ve created the Vehicles extension. Fill in your fleets’ specs and display your vehicles on connected tours and destinations. With a range of available options such as; type and number of gears, engine type (petrol/diesel), number of seats, vehicle code, and of course images and copy.', 'tour-operator' ); ?></p>
 
 				<div class="more-button">
 					<a href="<?php echo wp_kses_post( $vehicles_link ); ?>" target="_blank" class="button button-primary">

--- a/includes/template-tags/accommodation.php
+++ b/includes/template-tags/accommodation.php
@@ -132,11 +132,11 @@ function lsx_to_accommodation_facilities( $before = '', $after = '', $echo = tru
 		if ( count( $main_facilities ) > 0 && count( $child_facilities ) > 0 ) {
 			foreach ( $main_facilities as $heading ) {
 				if ( isset( $child_facilities[ $heading->term_id ] ) ) {
-					$return .= '<div class="' . $heading->slug . ' col-xs-12 col-sm-6"><div class="facilities-content"><h5 class="facilities-title"><a href="' . get_term_link( $heading->slug, 'facility' ) . '">' . esc_html( $heading->name ) . '</a></h5>';
+					$return .= '<div class="' . $heading->slug . ' col-xs-12 col-sm-6"><div class="facilities-content"><h5 class="facilities-title"><a href="' . esc_url( get_term_link( $heading->slug, 'facility' ) ) . '">' . esc_html( $heading->name ) . '</a></h5>';
 					$return .= '<ul class="facilities-list">';
 
 					foreach ( $child_facilities[ $heading->term_id ] as $child_facility ) {
-						$return .= '<li class="facility-item"><a href="' . get_term_link( $child_facility->slug, 'facility' ) . '">' . esc_html( $child_facility->name ) . '</a></li>';
+						$return .= '<li class="facility-item"><a href="' . esc_url( get_term_link( $child_facility->slug, 'facility' ) ) . '">' . esc_html( $child_facility->name ) . '</a></li>';
 					}
 
 					$return .= '</ul>';

--- a/includes/template-tags/general.php
+++ b/includes/template-tags/general.php
@@ -240,7 +240,7 @@ function lsx_to_page_navigation( $echo = true ) {
 
 		if ( ! empty( $page_links ) ) {
 			foreach ( $page_links as $link_slug => $link_value ) {
-				$return .= '<li><a href="#' . $link_slug . '">' . $link_value . '</a></li>';
+				$return .= '<li><a href="#' . esc_html( $link_slug ) . '">' . $link_value . '</a></li>';
 			}
 		}
 

--- a/includes/template-tags/general.php
+++ b/includes/template-tags/general.php
@@ -490,7 +490,7 @@ function lsx_to_enquiry_contact( $before = '', $after = '' ) {
 				<div class="lsx-to-meta-data contact-number"><i class="fa fa-phone"></i> <a href="tel:+<?php echo esc_attr( $fields['enquiry_contact_phone'] ); ?>"><?php echo esc_html( $fields['enquiry_contact_phone'] ); ?></a></div>
 			<?php endif; ?>
 			<?php if ( ! empty( $fields['enquiry_contact_email'] ) ) : ?>
-				<div class="lsx-to-meta-data email"><i class="fa fa-envelope"></i> <a href="mailto:<?php echo esc_attr( $fields['enquiry_contact_email'] ); ?>"><?php echo esc_html( $fields['enquiry_contact_email'] ); ?></a></div>
+				<div class="lsx-to-meta-data email"><i class="fa fa-envelope"></i> <a href="mailto:<?php echo esc_attr( antispambot( $fields['enquiry_contact_email'] ) ); ?>"><?php echo esc_html( $fields['enquiry_contact_email'] ); ?></a></div>
 			<?php endif; ?>
 		</div>
 	</article>

--- a/includes/template-tags/helpers.php
+++ b/includes/template-tags/helpers.php
@@ -219,7 +219,7 @@ if ( ! function_exists( 'lsx_to_get_term_thumbnail' ) ) {
 			$term_thumbnail_id = get_term_meta( $term_id, 'thumbnail', true );
 			$img               = wp_get_attachment_image_src( $term_thumbnail_id,$size );
 			$image_url         = $img[0];
-			$img               = '<img alt="thumbnail" class="attachment-responsive wp-post-image lsx-responsive" src="' . $image_url . '" />';
+			$img               = '<img alt="thumbnail" class="attachment-responsive wp-post-image lsx-responsive" src="' . esc_url( $image_url ) . '" />';
 			$img               = apply_filters( 'lsx_lazyload_slider_images', $img, $term_thumbnail_id, $size, false, $image_url );
 			return $img;
 		}

--- a/templates/content-widget-accommodation-brand.php
+++ b/templates/content-widget-accommodation-brand.php
@@ -26,7 +26,7 @@ if ( empty( $disable_single_link ) ) {
 		<?php else : ?>
 			<div class="lsx-to-widget-thumb">
 				<?php if ( ! empty( $title_link ) ) { ?><a href="<?php echo esc_url( $title_link ); ?>"><?php } ?>
-					<img alt="Placeholder" class="attachment-responsive wp-post-image lsx-responsive" src="<?php echo esc_attr( lsx\legacy\Placeholders::placeholder_url( null, null, array( 750, 350 ) ) ); ?>">
+					<img alt="Placeholder" class="attachment-responsive wp-post-image lsx-responsive" src="<?php echo esc_url( lsx\legacy\Placeholders::placeholder_url( null, null, array( 750, 350 ) ) ); ?>">
 				<?php if ( ! empty( $title_link ) ) { ?></a><?php } ?>
 			</div>
 		<?php endif; ?>

--- a/templates/content-widget-accommodation-type.php
+++ b/templates/content-widget-accommodation-type.php
@@ -26,7 +26,7 @@ if ( empty( $disable_single_link ) ) {
 		<?php else : ?>
 			<div class="lsx-to-widget-thumb">
 				<?php if ( ! empty( $title_link ) ) { ?><a href="<?php echo esc_url( $title_link ); ?>"><?php } ?>
-					<img alt="Placeholder" class="attachment-responsive wp-post-image lsx-responsive" src="<?php echo esc_attr( lsx\legacy\Placeholders::placeholder_url( null, null, array( 750, 350 ) ) ); ?>">
+					<img alt="Placeholder" class="attachment-responsive wp-post-image lsx-responsive" src="<?php echo esc_url( lsx\legacy\Placeholders::placeholder_url( null, null, array( 750, 350 ) ) ); ?>">
 				<?php if ( ! empty( $title_link ) ) { ?></a><?php } ?>
 			</div>
 		<?php endif; ?>

--- a/templates/content-widget-travel-style.php
+++ b/templates/content-widget-travel-style.php
@@ -26,7 +26,7 @@ if ( empty( $disable_single_link ) ) {
 		<?php else : ?>
 			<div class="lsx-to-widget-thumb">
 				<?php if ( ! empty( $title_link ) ) { ?><a href="<?php echo esc_url( $title_link ); ?>"><?php } ?>
-					<img alt="Placeholder" class="attachment-responsive wp-post-image lsx-responsive" src="<?php echo esc_attr( lsx\legacy\Placeholders::placeholder_url( null, null, array( 750, 350 ) ) ); ?>">
+					<img alt="Placeholder" class="attachment-responsive wp-post-image lsx-responsive" src="<?php echo esc_url( lsx\legacy\Placeholders::placeholder_url( null, null, array( 750, 350 ) ) ); ?>">
 				<?php if ( ! empty( $title_link ) ) { ?></a><?php } ?>
 			</div>
 		<?php endif; ?>

--- a/vendor/Custom-Meta-Boxes/classes.fields.php
+++ b/vendor/Custom-Meta-Boxes/classes.fields.php
@@ -449,7 +449,7 @@ class CMB_File_Field extends CMB_Field {
 		if ( $this->get_value() ) {
 			$src = wp_mime_type_icon( $this->get_value() );
 			$size = getimagesize( str_replace( site_url(), ABSPATH, $src ) );
-			$icon_img = '<img src="' . $src . '" ' . $size[3] . ' />';
+			$icon_img = '<img src="' . esc_url( $src ) . '" ' . $size[3] . ' />';
 		}
 
 		$data_type = ( ! empty( $this->args['library-type'] ) ? implode( ',', $this->args['library-type'] ) : null );


### PR DESCRIPTION
**Problem**
All of the widgets in `clases-widget.php` need a full re-coding of the widgets' update() methods. Most of them are not sanitized properly or not sanitized at all, `strip_tags()` is not really acceptable for satination for most options.
Also there is other scaping issues that can be fixed, using `antispambot()` function before showing email on front end.
Also check other Output escaping issues when when sanitizing URLs.

**Solution**
Change it to have the most appropriate method for the type of data that you expect. Don't just run `strip_tags()` over everything. Add validations for urls, satinations for text or ranges, etc.
Use right tags for showing emails.
Always use esc_url when sanitizing URLs.

**Testing**
Test a widget that is built with TO, changing and adding and removing fields and see that the front end widget delivers the right information.
Test the enquire contact forms.