### PR TITLE
Fix/compatibility wp 5.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Dev - Added in a filter 'lsx_to_maps_tour_connections' to allow 3rd party filters of the tour itinerary map connections.
 * Dev - Sanitizing widget fields.
 * Fix - Fix output escaping issues.
+* Fix - Fixed issue `PHP Deprecated: dbx_post_advanced is deprecated since version 3.7.0! Use add_meta_boxes instead`.
 
 ### 1.4.0 - 19 December 2019
 * Dev - Added in a parameter to lsx_to_enquire_modal() to allow a form_id to be specified

--- a/vendor/Custom-Meta-Boxes/class.cmb-meta-box.php
+++ b/vendor/Custom-Meta-Boxes/class.cmb-meta-box.php
@@ -15,7 +15,7 @@ class CMB_Meta_Box {
 		if ( empty( $this->_meta_box['id'] ) )
 			$this->_meta_box['id'] = sanitize_title( $this->_meta_box['title'] );
 
-		add_action( 'dbx_post_advanced', array( &$this, 'init_fields_for_post' ) );
+		add_action( 'add_meta_boxes', array( &$this, 'init_fields_for_post' ) );
 		add_action( 'cmb_init_fields', array( &$this, 'init_fields' ) );
 
 		add_action( 'admin_menu', array( &$this, 'add' ) );


### PR DESCRIPTION
### Description of the Change

This pull request is for fixing issue `PHP Deprecated: dbx_post_advanced is deprecated since version 3.7.0! Use add_meta_boxes instead`.

### Benefits

No PHP error from this issue, that will improve performance.

### Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

* Fix - Fixed issue `PHP Deprecated: dbx_post_advanced is deprecated since version 3.7.0! Use add_meta_boxes instead`.
