### PR TITLE
Removing lazyload functions

### DIFF
--- a/includes/classes/legacy/class-taxonomy-widget.php
+++ b/includes/classes/legacy/class-taxonomy-widget.php
@@ -535,7 +535,6 @@ class Taxonomy_Widget extends \WP_Widget {
 
 		if ( $carousel ) {
 			$output .= "<div class='lsx-to-widget-item-wrap lsx-{$taxonomy}'>";
-			add_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
 		} elseif ( 1 === $count ) {
 			$output .= "<div class='row'>";
 		}
@@ -550,7 +549,6 @@ class Taxonomy_Widget extends \WP_Widget {
 
 		if ( $carousel ) {
 			$output .= '</div>';
-			remove_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
 		} elseif ( 0 === $count % $columns || $count === $post_count ) {
 			$output .= '</div>';
 			if ( $count < $post_count ) {
@@ -615,33 +613,6 @@ class Taxonomy_Widget extends \WP_Widget {
 		}
 	}
 
-	/**
-	 * Applies the lazy loading if needed.
-	 *
-	 * @param String $img
-	 * @return void
-	 */
-	public function lazyload_slider_images( $img, $post_thumbnail_id, $size, $srcset, $image_url ) {
-		$lazyload = true;
-		if ( get_theme_mod( 'lsx_lazyload_status', '1' ) === false || ! apply_filters( 'lsx_lazyload_is_enabled', true ) ) {
-			$lazyload = false;
-		}
-		$lazy_img = '';
-		if ( true === $lazyload && '' !== $img ) {
-			$temp_lazy = wp_get_attachment_image_src( $post_thumbnail_id, $size );
-			if ( ! empty( $temp_lazy ) ) {
-				$lazy_img = $temp_lazy[0];
-			}
-			$img = '<img alt="' . the_title_attribute( 'echo=0' ) . '" class="attachment-responsive wp-post-image lsx-responsive" ';
-			if ( $srcset ) {
-				$img .= 'data-lazy="' . $lazy_img . '" srcset="' . esc_attr( $image_url ) . '" ';
-			} else {
-				$img .= 'data-lazy="' . esc_url( $image_url ) . '" ';
-			}
-			$img .= '/>';
-		}
-		return $img;
-	}
 }
 
 ?>

--- a/includes/classes/legacy/class-widget.php
+++ b/includes/classes/legacy/class-widget.php
@@ -622,7 +622,6 @@ class Widget extends \WP_Widget {
 		// Get the call for the active slide.
 		if ( $carousel ) {
 			$output .= "<div class='lsx-to-widget-item-wrap lsx-{$post_type}'>";
-			add_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
 		} elseif ( 1 === $count ) {
 			$output .= "<div class='row'>";
 		}
@@ -638,7 +637,6 @@ class Widget extends \WP_Widget {
 		// Close the current slide panel
 		if ( $carousel ) {
 			$output .= '</div>';
-			remove_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
 		} elseif ( 0 === $count % $columns || $count === $post_count ) {
 			$output .= '</div>';
 
@@ -706,32 +704,5 @@ class Widget extends \WP_Widget {
 		}
 	}
 
-	/**
-	 * Applies the lazy loading if needed.
-	 *
-	 * @param String $img
-	 * @return void
-	 */
-	public function lazyload_slider_images( $img, $post_thumbnail_id, $size, $srcset, $image_url ) {
-		$lazyload = true;
-		if ( get_theme_mod( 'lsx_lazyload_status', '1' ) === false || ! apply_filters( 'lsx_lazyload_is_enabled', true ) ) {
-			$lazyload = false;
-		}
-		$lazy_img = '';
-		if ( true === $lazyload && '' !== $img ) {
-			$temp_lazy = wp_get_attachment_image_src( $post_thumbnail_id, $size );
-			if ( ! empty( $temp_lazy ) ) {
-				$lazy_img = $temp_lazy[0];
-			}
-			$img = '<img alt="' . the_title_attribute( 'echo=0' ) . '" class="attachment-responsive wp-post-image lsx-responsive" ';
-			if ( $srcset ) {
-				$img .= 'data-lazy="' . $lazy_img . '" srcset="' . esc_attr( $image_url ) . '" ';
-			} else {
-				$img .= 'data-lazy="' . esc_url( $image_url ) . '" ';
-			}
-			$img .= '/>';
-		}
-		return $img;
-	}
 }
 ?>

--- a/includes/layout.php
+++ b/includes/layout.php
@@ -552,7 +552,7 @@ function lsx_to_tour_single_content_bottom() {
 									<div class="lsx-to-archive-container">
 										<div class="lsx-to-archive-thumb">
 											<div class="lsx-to-thumb-slot" style="background-image: url('<?php echo esc_url( $thumb ); ?>');">
-												<?php echo wp_kses_post( apply_filters( 'lsx_to_lazyload_filter_images', '<img alt="thumbnail" class="attachment-responsive wp-post-image lsx-responsive" src="' . $thumb . '">' ) ); ?>
+												<?php echo wp_kses_post( '<img alt="thumbnail" class="attachment-responsive wp-post-image lsx-responsive" src="' . $thumb . '">' ); ?>
 											</div>
 										</div>
 

--- a/includes/template-tags/general.php
+++ b/includes/template-tags/general.php
@@ -476,7 +476,7 @@ function lsx_to_enquiry_contact( $before = '', $after = '' ) {
 	<article <?php post_class(); ?>>
 		<?php if ( ! empty( $fields['enquiry_contact_image'] ) ) : ?>
 			<div class="lsx-to-contact-thumb">
-				<?php echo wp_kses_post( apply_filters( 'lsx_to_lazyload_filter_images', '<img alt="' . esc_attr( $fields['enquiry_contact_name'] ) . '" class="attachment-responsive wp-post-image lsx-responsive" src="' . esc_url( $fields['enquiry_contact_image'] ) . '" />' ) ); ?>
+				<?php echo wp_kses_post( '<img alt="' . esc_attr( $fields['enquiry_contact_name'] ) . '" class="attachment-responsive wp-post-image lsx-responsive" src="' . esc_url( $fields['enquiry_contact_image'] ) . '" />' ); ?>
 			</div>
 		<?php endif; ?>
 

--- a/includes/template-tags/helpers.php
+++ b/includes/template-tags/helpers.php
@@ -220,7 +220,6 @@ if ( ! function_exists( 'lsx_to_get_term_thumbnail' ) ) {
 			$img               = wp_get_attachment_image_src( $term_thumbnail_id,$size );
 			$image_url         = $img[0];
 			$img               = '<img alt="thumbnail" class="attachment-responsive wp-post-image lsx-responsive" src="' . esc_url( $image_url ) . '" />';
-			$img               = apply_filters( 'lsx_lazyload_slider_images', $img, $term_thumbnail_id, $size, false, $image_url );
 			return $img;
 		}
 	}


### PR DESCRIPTION
### Changes

Added support for native Lazy-loading images on WordPress 5.5 version.

### Benefits

- Support for WP 5.5 features.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/425

### Changelog Entry

#### Added
- Added support for native Lazy-loading images on WordPress 5.5 version.
