### PR TITLE
Adding in the post field support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Updated the departure day to reply on the previous days Location and Accommodation values. [#491](https://github.com/lightspeedwp/tour-operator/pull/491)
 - Block list updates - taken the blocks that were all listed in the assets folder and have broken them out into individual files along with block.json files - PR [#489](https://github.com/lightspeedwp/tour-operator/pull/489)
 - Removing the debug statements, A filter to allow the disabling of destinations when searching for related content. Prepping the registration for the adjust block registration. Refactoring the query statments into seperate functions. Fixing the filters for the related connections - PR (#486)
+- Added in the Related post connections to the single posts. - [#595](https://github.com/lightspeedwp/tour-operator/issues/595)
 
 ### Integrations
 - Added integration with the Action Scheduler to allow Tours to expire and be set to draft [#490](https://github.com/lightspeedwp/tour-operator/pull/490). Work with any plugin using the Action Scheduler as a vendor [WooCommerce](https://woocommerce.com/), [PublishPress](https://publishpress.com/), [Action Scheduler](https://wordpress.org/plugins/action-scheduler/).

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@
 - Updated the departure day to reply on the previous days Location and Accommodation values. [#491](https://github.com/lightspeedwp/tour-operator/pull/491)
 - Block list updates - taken the blocks that were all listed in the assets folder and have broken them out into individual files along with block.json files - PR [#489](https://github.com/lightspeedwp/tour-operator/pull/489)
 - Removing the debug statements, A filter to allow the disabling of destinations when searching for related content. Prepping the registration for the adjust block registration. Refactoring the query statments into seperate functions. Fixing the filters for the related connections - PR (#486)
-- Added in the Related post connections to the single posts. - [#595](https://github.com/lightspeedwp/tour-operator/issues/595)
+- Added Related post connections to the single posts. - [#595](https://github.com/lightspeedwp/tour-operator/issues/595)
 
 ### Integrations
 - Added integration with the Action Scheduler to allow Tours to expire and be set to draft [#490](https://github.com/lightspeedwp/tour-operator/pull/490). Work with any plugin using the Action Scheduler as a vendor [WooCommerce](https://woocommerce.com/), [PublishPress](https://publishpress.com/), [Action Scheduler](https://wordpress.org/plugins/action-scheduler/).

--- a/includes/classes/admin/class-setup.php
+++ b/includes/classes/admin/class-setup.php
@@ -34,6 +34,7 @@ class Setup {
 	 * @var     array
 	 */
 	public $post_types = [
+		'post',
 		'tour',
 		'accommodation',
 		'destination',

--- a/includes/classes/legacy/class-tour-operator.php
+++ b/includes/classes/legacy/class-tour-operator.php
@@ -390,11 +390,13 @@ class Tour_Operator {
 	 * Generates the post_connections used in the metabox fields
 	 */
 	public function create_post_connections() {
-		$connections = array();
-		$post_types  = apply_filters( 'lsx_to_post_types', $this->post_types );
+		$connections        = [];
+		$post_types         = [];
+		$post_types         = apply_filters( 'lsx_to_post_types', $this->post_types );
+		$post_types['post'] = __( 'Posts', 'tour-operator' );
 
 		foreach ( $post_types as $key_a => $values_a ) {
-			foreach ( $this->post_types as $key_b => $values_b ) {
+			foreach ( $post_types as $key_b => $values_b ) {
 				// Make sure we dont try connect a post type to itself.
 				if ( $key_a !== $key_b ) {
 					$connections[] = $key_a . '_to_' . $key_b;

--- a/includes/metaboxes/config-post.php
+++ b/includes/metaboxes/config-post.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tour Operator - Post Metabox config
+ *
+ * @package   tour_operator
+ * @author    LightSpeed
+ * @license   GPL-2.0+
+ * @link
+ * @copyright 2025 LightSpeedDevelopment
+ */
+
+$metabox = array(
+	'title'  => esc_html__( 'Details', 'tour-operator' ),
+	'pages'  => 'post',
+	'fields' => array(),
+);
+
+$metabox['fields'][] = array(
+	'id'   => 'related_title',
+	'name' => esc_html__( 'Related', 'tour-operator' ),
+	'type' => 'title',
+);
+
+$metabox['fields'][] = array(
+	'id'         => 'accommodation_to_post',
+	'name'       => esc_html__( 'Related Accommodation', 'tour-operator' ),
+	'desc'       => esc_html__( 'Select accommodation related to this post.', 'tour-operator' ),
+	'type'       => 'pw_multiselect',
+	'use_ajax'   => false,
+	'repeatable' => false,
+	'allow_none' => true,
+	'options'  => array(
+		'post_type_args' => 'accommodation',
+	),
+);
+
+$metabox['fields'][] = array(
+	'id'         => 'destination_to_post',
+	'name'       => esc_html__( 'Related Destinations', 'tour-operator' ),
+	'desc'       => esc_html__( 'The Destination (country or region) where this post is found.', 'tour-operator' ),
+	'type'       => 'pw_multiselect',
+	'use_ajax'   => false,
+	'repeatable' => false,
+	'allow_none' => true,
+	'options'  => array(
+		'post_type_args' => 'destination',
+	),
+);
+
+$metabox['fields'][] = array(
+	'id'         => 'tour_to_post',
+	'name'       => esc_html__( 'Related Tours', 'tour-operator' ),
+	'desc'       => esc_html__( 'Choose tours that are linked to the post.', 'tour-operator' ),
+	'type'       => 'pw_multiselect',
+	'use_ajax'   => false,
+	'repeatable' => false,
+	'allow_none' => true,
+	'options'  => array(
+		'post_type_args' => 'tour',
+	),
+);
+
+$metabox['fields'] = apply_filters( 'lsx_to_post_custom_fields', $metabox['fields'] );
+
+return $metabox;


### PR DESCRIPTION
### Description
The "related" post connections have been extended to the post again, allowing you to connect tours, accommodaiton, destinations and the extensions to the posts.

### Issue
#595 

### Screenshots
<img width="1008" height="738" alt="Screenshot 2025-08-15 at 11 24 45" src="https://github.com/user-attachments/assets/17bedff4-8e55-4192-9956-35a6ef2e10e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Related connections on single post screens to link Posts with Accommodation, Destination and Tours.
  - Introduced a “Details” section in the post editor for selecting related content via new relationship fields.
  - Enabled these relationship controls for standard Posts in addition to existing content types.

- Documentation
  - Added changelog entry under Enhancements for the upcoming 2.1.0 release noting Related post connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->