### PR TITLE
Merge 2.1-bugherd-fixes into 2.1-trunk

### DIFF
--- a/includes/classes/blocks/class-bindings.php
+++ b/includes/classes/blocks/class-bindings.php
@@ -784,6 +784,7 @@ class Bindings {
 		}
 
 		$classes = $this->find_gallery_classes( $block_content );
+		$styles  = $this->find_gallery_styles( $block_content );
 		$images  = array();
 		$count   = 1;
 
@@ -797,13 +798,34 @@ class Bindings {
 			$count++;
 		}
 
-		$block_content = '<figure class="lsx-block-videos ' . $classes . '">' . implode( '', $images ) . '</figure>';
+		$block_content = '<figure ' . $styles . ' class="lsx-block-videos ' . $classes . '">' . implode( '', $images ) . '</figure>';
 
 		// Ensure the core/embed block styles are loaded for video embeds
 		if ( ! wp_style_is( 'wp-block-embed', 'enqueued' ) ) {
 			wp_enqueue_style( 'wp-block-embed' );
 		}
 		return $block_content;
+	}
+
+	/**
+	 * Finds all style attribute of the current gallery.
+	 *
+	 * @param string $content The original HTML content.
+	 * @param string $prefix The css classname prefix before the -description.
+	 * @return string An string containing class names found with "{$prefix}-description".
+	 */
+	public function find_gallery_styles( $content ) {
+		$style_attr = '';
+		// Match a <figure> that has class including wp-block-gallery and capture its style attribute value (style may appear anywhere in the tag).
+		$pattern = '/<figure\b(?=[^>]*\bclass="[^"]*\bwp-block-gallery\b[^"]*")(?=[^>]*\bstyle=(["\"])((?:(?!\1).)*)\1)[^>]*>/is';
+		if ( preg_match( $pattern, $content, $matches ) ) {
+			// $matches[2] holds the style value without quotes due to nested groups.
+			$style_value = trim( $matches[2] );
+			if ( '' !== $style_value ) {
+				$style_attr = 'style="' . esc_attr( $style_value ) . '"';
+			}
+		}
+		return $style_attr;
 	}
 
 	/**

--- a/includes/classes/blocks/class-query-loop.php
+++ b/includes/classes/blocks/class-query-loop.php
@@ -358,8 +358,6 @@ class Query_Loop {
 					$query['post__in'] = $items;
 				}
 
-				
-
 				$query = $this->related_taxonomy_query( $query, $key );
 
 				if ( ! isset( $query['post__in'] ) && ! isset( $query['tax_query'] ) ) {
@@ -387,6 +385,8 @@ class Query_Loop {
 
 				// Find the items stored in the relevant connection custom field.
 				$items = $this->related_connection_query( $items, $to, $from );
+
+				do_action( 'qm/debug', [ $key, $items ] );
 
 				if ( ! empty( $items ) ) {
 					$items = array_unique( $items );

--- a/includes/classes/blocks/class-query-loop.php
+++ b/includes/classes/blocks/class-query-loop.php
@@ -386,8 +386,6 @@ class Query_Loop {
 				// Find the items stored in the relevant connection custom field.
 				$items = $this->related_connection_query( $items, $to, $from );
 
-				do_action( 'qm/debug', [ $key, $items ] );
-
 				if ( ! empty( $items ) ) {
 					$items = array_unique( $items );
 					$query['post__in'] = $items;

--- a/includes/classes/legacy/class-admin.php
+++ b/includes/classes/legacy/class-admin.php
@@ -170,8 +170,11 @@ class Admin extends Tour_Operator {
 
 			if ( isset( $field->data_to_save[ $field_id ] ) ) {
 				$new_values = $field->data_to_save[ $field_id ];
+				if ( ! is_array( $new_values ) ) {
+					$new_values = [ $new_values ];
+				}
 			} else {
-				$new_values = array();
+				$new_values = [];
 			}
 
 			//if the new values are empty, then we need to remove the previous values.

--- a/includes/classes/legacy/class-placeholders.php
+++ b/includes/classes/legacy/class-placeholders.php
@@ -66,6 +66,9 @@ class Placeholders {
 				'default_term_thumbnail',
 			), 11, 3 );
 
+			// Ensure a placeholder attachment ID is returned for core get_post_thumbnail_id() calls.
+			add_filter( 'post_thumbnail_id', array( $this, 'filter_post_thumbnail_id' ), 10, 2 );
+
 			add_filter( 'wp_get_attachment_image_src', array(
 				$this,
 				'super_placeholder_filter',
@@ -394,5 +397,53 @@ class Placeholders {
 		}
 
 		return $sources;
+	}
+
+	/**
+	 * Filter for 'post_thumbnail_id' to provide a placeholder attachment ID when missing.
+	 *
+	 * This runs after core has already cast the meta value to an int. If no thumbnail
+	 * is set (0) we attempt to fetch a configured placeholder attachment ID so that
+	 * template functions like get_the_post_thumbnail() will render a real image tag
+	 * instead of returning an empty string.
+	 *
+	 * @param int             $thumbnail_id Current (numeric) thumbnail ID, possibly 0.
+	 * @param int|\WP_Post    $post         Post object or ID passed by the filter.
+	 *
+	 * @return int Filtered thumbnail ID.
+	 */
+	public function filter_post_thumbnail_id( $thumbnail_id, $post ) {
+		// If a valid thumbnail already exists, leave it alone.
+		if ( ! empty( $thumbnail_id ) ) {
+			return $thumbnail_id;
+		}
+
+		$post_obj = is_object( $post ) ? $post : get_post( $post );
+		if ( ! $post_obj ) {
+			return $thumbnail_id; // Leave as-is if post can't be resolved.
+		}
+
+		$options   = get_option( 'lsx_to_settings', false );
+		$post_type = $post_obj->post_type;
+
+		if ( ! is_array( $options ) ) {
+			return $thumbnail_id; // Nothing we can do.
+		}
+
+		$placeholder_id = 0;
+
+		// New flat structure keys:
+		// Global default: featured_placeholder
+		// Per post type: {post_type}_featured_placeholder
+		if ( ! empty( $options['featured_placeholder'] ) ) {
+			$placeholder_id = (int) $options['featured_placeholder'];
+		}
+
+		$pt_key = $post_type . '_featured_placeholder';
+		if ( ! empty( $options[ $pt_key ] ) ) {
+			$placeholder_id = (int) $options[ $pt_key ];
+		}
+
+		return $placeholder_id > 0 ? $placeholder_id : $thumbnail_id;
 	}
 }

--- a/src/js/custom.js
+++ b/src/js/custom.js
@@ -374,7 +374,9 @@ lsx_to.set_read_more = function () {
         }
 
         $this.removeClass('is-layout-flex wp-block-gallery-is-layout-flex is-layout-grid');
-
+		// Remove any left/right padding explicitly set (inline or inherited) to allow full-width slider alignment.
+		$this.css({ 'padding-left': 0, 'padding-right': 0 });
+        
         if (1 < $this.children().length) {
           $this.slick({
             draggable: false,
@@ -526,7 +528,7 @@ lsx_to.set_read_more = function () {
     lsx_to.build_slider_lightbox();
   });
 
-  document.addEventListener("DOMContentLoaded", function () {
+  /*document.addEventListener("DOMContentLoaded", function () {
     // Select all sections within `.single-tour-operator`
     const sections = document.querySelectorAll(
       ".single-tour-operator section.wp-block-group, .single-tour-operator section.wp-block-cover"
@@ -570,5 +572,5 @@ lsx_to.set_read_more = function () {
         });
       }
     });
-  });
+  });*/
 })(jQuery, window, document);


### PR DESCRIPTION
# Description
Merges the latest changes from the `2.1-bugherd-fixes` branch into `2.1-trunk`. This includes all recent bugherd fixes for the 2.1 release.

# Type of Change
- Bugfix (non-breaking change which fixes an issue)

# Benefits
- Ensures all bugherd fixes are present in the trunk branch for 2.1

# Possible Drawbacks
- None expected, but please review for any merge conflicts or regressions

# Alternate Designs
- N/A

# Checklist
- [x] I agree to follow this project's [Code of Conduct](https://github.com/lightspeedwp/.github/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I have read the [CONTRIBUTING guidelines](https://github.com/lightspeedwp/.github/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Linting and tests pass locally with my changes
- [x] I have added or updated documentation as needed
- [x] I have added tests to cover my change
- [x] All new and existing tests pass

# How to Test
- Review the merged code for bugherd fixes
- Run tests and verify no regressions

# Applicable Issues
- N/A

# Changelog Entry
- Bugherd fixes for 2.1

# Credits
Props @krugazul

# Additional Links
- [Code](https://github.com/lightspeedwp/.github)
- [Issues](https://github.com/lightspeedwp/.github/issues)
- [Pull requests](https://github.com/lightspeedwp/.github/pulls)
- [Actions](https://github.com/lightspeedwp/.github/actions)
- [Projects](https://github.com/lightspeedwp/.github/projects)
- [Models](https://github.com/lightspeedwp/.github/models)
- [.github](https://github.com/lightspeedwp/.github/tree/master)
- [.github](https://github.com/lightspeedwp/.github/tree/master/.github)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic placeholder featured images display when no thumbnail is set.
* Improvements
  * Video/gallery blocks now retain gallery-applied styles.
  * Sliders and “Read more” sections align edge-to-edge with corrected padding.
* Bug Fixes
  * More reliable saving of related item selections to prevent inconsistent values.
* Behaviour Changes
  * Auto-toggling within single tour operator sections is disabled.
* Style
  * Minor code clean-up with no impact on behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->