### PR TITLE
Enhance check-in and check-out blocks with meta and post types

### DIFF
--- a/build/blocks/checkin-time/block.json
+++ b/build/blocks/checkin-time/block.json
@@ -34,7 +34,7 @@
           [
             "core/paragraph",
             {
-              "content": "3:00 PM"
+              "content": "11:00 AM"
             }
           ]
         ]

--- a/build/blocks/checkin-time/block.json
+++ b/build/blocks/checkin-time/block.json
@@ -1,8 +1,44 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
+  "textdomain": "tour-operator",
   "name": "lsx-tour-operator/checkin-time",
   "title": "Check In Time",
   "category": "lsx-tour-operator",
-  "editorScript": "file:index.js"
+  "editorScript": "file:index.js",
+  "description": "Show accommodation check-in time and procedures.",
+  "icon": "clock",
+  "keywords": [
+    "checkin",
+    "time",
+    "arrival"
+  ],
+  "example": {
+    "attributes": {
+      "metadata": {
+        "name": "Check In Time"
+      }
+    },
+    "innerBlocks": [
+      [
+        "core/group",
+        {},
+        [
+          [
+            "core/heading",
+            {
+              "content": "Check In Time",
+              "level": 3
+            }
+          ],
+          [
+            "core/paragraph",
+            {
+              "content": "3:00 PM"
+            }
+          ]
+        ]
+      ]
+    ]
+  }
 }

--- a/build/blocks/checkin-time/index.asset.php
+++ b/build/blocks/checkin-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array(), 'version' => '857d6450e8c7c1c40617');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => 'd1331d42f9379a194249');

--- a/build/blocks/checkin-time/index.asset.php
+++ b/build/blocks/checkin-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-i18n'), 'version' => '11de3a8524ed2ddd7d17');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => '3482e7fb705aff9b948a');

--- a/build/blocks/checkin-time/index.asset.php
+++ b/build/blocks/checkin-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-i18n'), 'version' => 'd1331d42f9379a194249');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => '8c4827b434086a2fd463');

--- a/build/blocks/checkin-time/index.asset.php
+++ b/build/blocks/checkin-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-i18n'), 'version' => '8c4827b434086a2fd463');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => '11de3a8524ed2ddd7d17');

--- a/build/blocks/checkin-time/index.asset.php
+++ b/build/blocks/checkin-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array(), 'version' => '406ed9016c7d326389a3');
+<?php return array('dependencies' => array(), 'version' => '857d6450e8c7c1c40617');

--- a/build/blocks/checkin-time/index.js
+++ b/build/blocks/checkin-time/index.js
@@ -90,9 +90,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/i18n */ "@wordpress/i18n");
 /* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__);
 /**
- * Check Out Time Block Variation
+ * Check In Time Block Variation
  *
- * Registers a block variation for accommodation check-out time display.
+ * Registers a block variation for accommodation check-in time display.
  * Only available on accommodation post type edit screens.
  *
  * @since 2.1.0
@@ -119,7 +119,7 @@ wp.domReady(() => {
         category: "lsx-tour-operator",
         attributes: {
           metadata: {
-            name: "Check in Time"
+            name: "Check In Time"
           },
           className: "lsx-checkin-time-wrapper",
           layout: {

--- a/build/blocks/checkin-time/index.js
+++ b/build/blocks/checkin-time/index.js
@@ -100,6 +100,77 @@ __webpack_require__.r(__webpack_exports__);
  */
 
 
+function registerCheckinTimeVariation() {
+  try {
+    wp.blocks.registerBlockVariation('core/group', {
+      name: 'lsx-tour-operator/checkin-time',
+      title: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time', 'tour-operator'),
+      icon: 'clock',
+      category: 'lsx-tour-operator',
+      isActive: (blockAttributes, variationAttributes) => {
+        return blockAttributes.metadata?.name === variationAttributes.metadata?.name;
+      },
+      attributes: {
+        metadata: {
+          name: 'Check in time'
+        },
+        className: 'lsx-checkin-time-wrapper',
+        layout: {
+          type: 'flex',
+          flexWrap: 'nowrap'
+        }
+      },
+      innerBlocks: [['core/group', {
+        layout: {
+          type: 'flex',
+          flexWrap: 'nowrap',
+          verticalAlignment: 'middle'
+        }
+      }, [['lsx-tour-operator/icons', {
+        iconType: 'solid',
+        iconName: 'checkInAccommodationIcon'
+      }], ['core/paragraph', {
+        content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time:', 'tour-operator')
+      }]]], ['core/group', {
+        layout: {
+          type: 'flex',
+          flexWrap: 'nowrap'
+        }
+      }, [['core/paragraph', {
+        metadata: {
+          bindings: {
+            content: {
+              source: 'lsx/post-meta',
+              args: {
+                key: 'checkin_time'
+              }
+            }
+          }
+        }
+      }]]]],
+      supports: {
+        renaming: false
+      },
+      example: {
+        attributes: {
+          metadata: {
+            name: 'Check in time'
+          }
+        },
+        innerBlocks: [['core/group', {}, [['core/heading', {
+          content: 'Check in time',
+          level: 3
+        }], ['core/paragraph', {
+          content: '11:00 AM'
+        }]]]]
+      }
+    });
+    return true;
+  } catch (error) {
+    console.error('Failed to register checkin-time block:', error);
+    return false;
+  }
+}
 wp.domReady(() => {
   const {
     select
@@ -107,74 +178,23 @@ wp.domReady(() => {
 
   // Define supported post types
   const supportedPostTypes = ['accommodation'];
+  let registered = false;
 
   // Check if current post type is supported
   const checkAndRegister = () => {
-    const postType = select('core/editor')?.getCurrentPostType();
-    if (postType && supportedPostTypes.includes(postType)) {
-      wp.blocks.registerBlockVariation("core/group", {
-        name: "lsx-tour-operator/checkin-time",
-        title: "Check In Time",
-        icon: "clock",
-        category: "lsx-tour-operator",
-        attributes: {
-          metadata: {
-            name: "Check In Time"
-          },
-          className: "lsx-checkin-time-wrapper",
-          layout: {
-            type: "flex",
-            flexWrap: "nowrap"
-          }
-        },
-        innerBlocks: [["core/group", {
-          layout: {
-            type: "flex",
-            flexWrap: "nowrap",
-            verticalAlignment: "middle"
-          }
-        }, [["lsx-tour-operator/icons", {
-          iconType: "solid",
-          iconName: "checkInAccommodationIcon"
-        }], ["core/paragraph", {
-          content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time:', 'tour-operator')
-        }]]], ["core/group", {
-          layout: {
-            type: "flex",
-            flexWrap: "nowrap"
-          }
-        }, [["core/paragraph", {
-          metadata: {
-            bindings: {
-              content: {
-                source: "lsx/post-meta",
-                args: {
-                  key: "checkin_time"
-                }
-              }
-            }
-          }
-        }]]]],
-        supports: {
-          renaming: false
-        },
-        example: {
-          attributes: {
-            metadata: {
-              name: "Check In Time"
-            }
-          },
-          innerBlocks: [["core/group", {}, [["core/heading", {
-            content: "Check In Time",
-            level: 3
-          }], ["core/paragraph", {
-            content: "11:00 AM"
-          }]]]]
-        }
-      });
-      return true; // Registration successful
+    if (registered) {
+      return true;
     }
-    return false; // Post type not ready or not supported
+    const postType = select('core/editor')?.getCurrentPostType();
+    const postSlug = select('core/editor')?.getEditedPostSlug();
+    if (!postType || !postSlug) {
+      return false;
+    }
+    if (supportedPostTypes.includes(postType) || (postType === 'wp_template' || postType === 'wp_template_part') && postSlug.includes('accommodation')) {
+      registerCheckinTimeVariation();
+      registered = true;
+    }
+    return registered;
   };
 
   // Try immediate registration

--- a/build/blocks/checkin-time/index.js
+++ b/build/blocks/checkin-time/index.js
@@ -1,1 +1,97 @@
-wp.domReady(()=>{wp.blocks.registerBlockVariation("core/group",{name:"lsx-tour-operator/checkin-time",title:"Check In Time",icon:"clock",category:"lsx-tour-operator",attributes:{metadata:{name:"Check In Time"},className:"lsx-checkin-time-wrapper",layout:{type:"flex",flexWrap:"nowrap"}},innerBlocks:[["core/group",{layout:{type:"flex",flexWrap:"nowrap",verticalAlignment:"top"}},[["core/image",{id:122720,width:"20px",sizeSlug:"large",linkDestination:"none",url:lsxToEditor.assetsUrl+"blocks/check-in-check-out-time.svg",alt:"",className:"wp-image-122720"}],["core/paragraph",{content:"<strong>Check in time:</strong>"}]]],["core/group",{layout:{type:"flex",flexWrap:"nowrap"}},[["core/paragraph",{metadata:{bindings:{content:{source:"lsx/post-meta",args:{key:"checkin_time"}}}}}]]]],supports:{renaming:!1}})});
+/******/ (function() { // webpackBootstrap
+/*!******************************************!*\
+  !*** ./src/blocks/checkin-time/index.js ***!
+  \******************************************/
+wp.domReady(() => {
+  const {
+    select
+  } = wp.data;
+
+  // Define supported post types
+  const supportedPostTypes = ['accommodation'];
+
+  // Check if current post type is supported
+  const checkAndRegister = () => {
+    const postType = select('core/editor')?.getCurrentPostType();
+    if (postType && supportedPostTypes.includes(postType)) {
+      wp.blocks.registerBlockVariation("core/group", {
+        name: "lsx-tour-operator/checkin-time",
+        title: "Check In Time",
+        icon: "clock",
+        category: "lsx-tour-operator",
+        attributes: {
+          metadata: {
+            name: "Check In Time"
+          },
+          className: "lsx-checkin-time-wrapper",
+          layout: {
+            type: "flex",
+            flexWrap: "nowrap"
+          }
+        },
+        innerBlocks: [["core/group", {
+          layout: {
+            type: "flex",
+            flexWrap: "nowrap",
+            verticalAlignment: "middle"
+          }
+        }, [["lsx-tour-operator/icons", {
+          iconType: "solid",
+          iconName: "checkInAccommodationIcon"
+        }], ["core/paragraph", {
+          content: "<strong>Check in time:</strong>"
+        }]]], ["core/group", {
+          layout: {
+            type: "flex",
+            flexWrap: "nowrap"
+          }
+        }, [["core/paragraph", {
+          metadata: {
+            bindings: {
+              content: {
+                source: "lsx/post-meta",
+                args: {
+                  key: "checkin_time"
+                }
+              }
+            }
+          }
+        }]]]],
+        supports: {
+          renaming: false
+        },
+        example: {
+          attributes: {
+            metadata: {
+              name: "Check In Time"
+            }
+          },
+          innerBlocks: [["core/group", {}, [["core/heading", {
+            content: "Check In Time",
+            level: 3
+          }], ["core/paragraph", {
+            content: "3:00 PM"
+          }]]]]
+        }
+      });
+      return true; // Registration successful
+    }
+    return false; // Post type not ready or not supported
+  };
+
+  // Try immediate registration
+  if (!checkAndRegister()) {
+    // If not ready, check periodically
+    const interval = setInterval(() => {
+      if (checkAndRegister()) {
+        clearInterval(interval);
+      }
+    }, 100);
+
+    // Clean up after 5 seconds to prevent infinite checking
+    setTimeout(() => clearInterval(interval), 5000);
+  }
+});
+/******/ })()
+;
+//# sourceMappingURL=index.js.map

--- a/build/blocks/checkin-time/index.js
+++ b/build/blocks/checkin-time/index.js
@@ -1,7 +1,105 @@
 /******/ (function() { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "@wordpress/i18n":
+/*!******************************!*\
+  !*** external ["wp","i18n"] ***!
+  \******************************/
+/***/ (function(module) {
+
+module.exports = window["wp"]["i18n"];
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	!function() {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = function(module) {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				function() { return module['default']; } :
+/******/ 				function() { return module; };
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	!function() {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = function(exports, definition) {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	!function() {
+/******/ 		__webpack_require__.o = function(obj, prop) { return Object.prototype.hasOwnProperty.call(obj, prop); }
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	!function() {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = function(exports) {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
+!function() {
 /*!******************************************!*\
   !*** ./src/blocks/checkin-time/index.js ***!
   \******************************************/
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/i18n */ "@wordpress/i18n");
+/* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__);
+/**
+ * Check Out Time Block Variation
+ *
+ * Registers a block variation for accommodation check-out time display.
+ * Only available on accommodation post type edit screens.
+ *
+ * @since 2.1.0
+ * @package Tour_Operator
+ */
+
+
 wp.domReady(() => {
   const {
     select
@@ -21,7 +119,7 @@ wp.domReady(() => {
         category: "lsx-tour-operator",
         attributes: {
           metadata: {
-            name: "Check In Time"
+            name: "Check in Time"
           },
           className: "lsx-checkin-time-wrapper",
           layout: {
@@ -39,7 +137,7 @@ wp.domReady(() => {
           iconType: "solid",
           iconName: "checkInAccommodationIcon"
         }], ["core/paragraph", {
-          content: "<strong>Check in time:</strong>"
+          content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time:', 'tour-operator')
         }]]], ["core/group", {
           layout: {
             type: "flex",
@@ -70,7 +168,7 @@ wp.domReady(() => {
             content: "Check In Time",
             level: 3
           }], ["core/paragraph", {
-            content: "3:00 PM"
+            content: "11:00 AM"
           }]]]]
         }
       });
@@ -92,6 +190,7 @@ wp.domReady(() => {
     setTimeout(() => clearInterval(interval), 5000);
   }
 });
+}();
 /******/ })()
 ;
 //# sourceMappingURL=index.js.map

--- a/build/blocks/checkin-time/index.js
+++ b/build/blocks/checkin-time/index.js
@@ -112,7 +112,7 @@ function registerCheckinTimeVariation() {
       },
       attributes: {
         metadata: {
-          name: 'Check in time'
+          name: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time', 'tour-operator')
         },
         className: 'lsx-checkin-time-wrapper',
         layout: {
@@ -154,11 +154,11 @@ function registerCheckinTimeVariation() {
       example: {
         attributes: {
           metadata: {
-            name: 'Check in time'
+            name: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time', 'tour-operator')
           }
         },
         innerBlocks: [['core/group', {}, [['core/heading', {
-          content: 'Check in time',
+          content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check in time', 'tour-operator'),
           level: 3
         }], ['core/paragraph', {
           content: '11:00 AM'

--- a/build/blocks/checkout-time/block.json
+++ b/build/blocks/checkout-time/block.json
@@ -1,8 +1,44 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
+  "textdomain": "tour-operator",
   "name": "lsx-tour-operator/checkout-time",
   "title": "Check Out Time",
   "category": "lsx-tour-operator",
-  "editorScript": "file:index.js"
+  "editorScript": "file:index.js",
+  "description": "Show accommodation check-out time and procedures.",
+  "icon": "clock",
+  "keywords": [
+    "checkout",
+    "time",
+    "departure"
+  ],
+  "example": {
+    "attributes": {
+      "metadata": {
+        "name": "Check Out Time"
+      }
+    },
+    "innerBlocks": [
+      [
+        "core/group",
+        {},
+        [
+          [
+            "core/heading",
+            {
+              "content": "Check Out Time",
+              "level": 3
+            }
+          ],
+          [
+            "core/paragraph",
+            {
+              "content": "11:00 AM"
+            }
+          ]
+        ]
+      ]
+    ]
+  }
 }

--- a/build/blocks/checkout-time/block.json
+++ b/build/blocks/checkout-time/block.json
@@ -34,7 +34,7 @@
           [
             "core/paragraph",
             {
-              "content": "11:00 AM"
+              "content": "3:00 PM"
             }
           ]
         ]

--- a/build/blocks/checkout-time/index.asset.php
+++ b/build/blocks/checkout-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array(), 'version' => '9212e9dbd8d927eaf375');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => '3d71aa25354e90f8d2dc');

--- a/build/blocks/checkout-time/index.asset.php
+++ b/build/blocks/checkout-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-i18n'), 'version' => '3d71aa25354e90f8d2dc');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => '5e819145f2e2d83c3692');

--- a/build/blocks/checkout-time/index.asset.php
+++ b/build/blocks/checkout-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array(), 'version' => '4601e6fbbe46cdc44d44');
+<?php return array('dependencies' => array(), 'version' => '9212e9dbd8d927eaf375');

--- a/build/blocks/checkout-time/index.asset.php
+++ b/build/blocks/checkout-time/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-i18n'), 'version' => '5e819145f2e2d83c3692');
+<?php return array('dependencies' => array('wp-i18n'), 'version' => '83eae5d69a3519ae7fbc');

--- a/build/blocks/checkout-time/index.js
+++ b/build/blocks/checkout-time/index.js
@@ -1,1 +1,97 @@
-wp.domReady(()=>{wp.blocks.registerBlockVariation("core/group",{name:"lsx-tour-operator/checkout-time",title:"Check Out Time",icon:"clock",category:"lsx-tour-operator",attributes:{metadata:{name:"Check Out Time"},className:"lsx-checkout-time-wrapper",layout:{type:"flex",flexWrap:"nowrap"}},innerBlocks:[["core/group",{layout:{type:"flex",flexWrap:"nowrap",verticalAlignment:"top"}},[["core/image",{id:122720,width:"20px",sizeSlug:"large",linkDestination:"none",url:lsxToEditor.assetsUrl+"blocks/check-in-check-out-time.svg",alt:"",className:"wp-image-122720"}],["core/paragraph",{content:"<strong>Check out time:</strong>"}]]],["core/group",{layout:{type:"flex",flexWrap:"nowrap"}},[["core/paragraph",{metadata:{bindings:{content:{source:"lsx/post-meta",args:{key:"checkout_time"}}}}}]]]],supports:{renaming:!1}})});
+/******/ (function() { // webpackBootstrap
+/*!*******************************************!*\
+  !*** ./src/blocks/checkout-time/index.js ***!
+  \*******************************************/
+wp.domReady(() => {
+  const {
+    select
+  } = wp.data;
+
+  // Define supported post types
+  const supportedPostTypes = ['accommodation'];
+
+  // Check if current post type is supported
+  const checkAndRegister = () => {
+    const postType = select('core/editor')?.getCurrentPostType();
+    if (postType && supportedPostTypes.includes(postType)) {
+      wp.blocks.registerBlockVariation("core/group", {
+        name: "lsx-tour-operator/checkout-time",
+        title: "Check Out Time",
+        icon: "clock",
+        category: "lsx-tour-operator",
+        attributes: {
+          metadata: {
+            name: "Check Out Time"
+          },
+          className: "lsx-checkout-time-wrapper",
+          layout: {
+            type: "flex",
+            flexWrap: "nowrap"
+          }
+        },
+        innerBlocks: [["core/group", {
+          layout: {
+            type: "flex",
+            flexWrap: "nowrap",
+            verticalAlignment: "middle"
+          }
+        }, [["lsx-tour-operator/icons", {
+          iconType: "solid",
+          iconName: "checkInAccommodationIcon"
+        }], ["core/paragraph", {
+          content: "<strong>Check out time:</strong>"
+        }]]], ["core/group", {
+          layout: {
+            type: "flex",
+            flexWrap: "nowrap"
+          }
+        }, [["core/paragraph", {
+          metadata: {
+            bindings: {
+              content: {
+                source: "lsx/post-meta",
+                args: {
+                  key: "checkout_time"
+                }
+              }
+            }
+          }
+        }]]]],
+        supports: {
+          renaming: false
+        },
+        example: {
+          attributes: {
+            metadata: {
+              name: "Check Out Time"
+            }
+          },
+          innerBlocks: [["core/group", {}, [["core/heading", {
+            content: "Check Out Time",
+            level: 3
+          }], ["core/paragraph", {
+            content: "11:00 AM"
+          }]]]]
+        }
+      });
+      return true; // Registration successful
+    }
+    return false; // Post type not ready or not supported
+  };
+
+  // Try immediate registration
+  if (!checkAndRegister()) {
+    // If not ready, check periodically
+    const interval = setInterval(() => {
+      if (checkAndRegister()) {
+        clearInterval(interval);
+      }
+    }, 100);
+
+    // Clean up after 5 seconds to prevent infinite checking
+    setTimeout(() => clearInterval(interval), 5000);
+  }
+});
+/******/ })()
+;
+//# sourceMappingURL=index.js.map

--- a/build/blocks/checkout-time/index.js
+++ b/build/blocks/checkout-time/index.js
@@ -1,7 +1,105 @@
 /******/ (function() { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "@wordpress/i18n":
+/*!******************************!*\
+  !*** external ["wp","i18n"] ***!
+  \******************************/
+/***/ (function(module) {
+
+module.exports = window["wp"]["i18n"];
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	!function() {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__webpack_require__.n = function(module) {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				function() { return module['default']; } :
+/******/ 				function() { return module; };
+/******/ 			__webpack_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	!function() {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__webpack_require__.d = function(exports, definition) {
+/******/ 			for(var key in definition) {
+/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	!function() {
+/******/ 		__webpack_require__.o = function(obj, prop) { return Object.prototype.hasOwnProperty.call(obj, prop); }
+/******/ 	}();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	!function() {
+/******/ 		// define __esModule on exports
+/******/ 		__webpack_require__.r = function(exports) {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	}();
+/******/ 	
+/************************************************************************/
+var __webpack_exports__ = {};
+// This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
+!function() {
 /*!*******************************************!*\
   !*** ./src/blocks/checkout-time/index.js ***!
   \*******************************************/
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @wordpress/i18n */ "@wordpress/i18n");
+/* harmony import */ var _wordpress_i18n__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__);
+/**
+ * Check Out Time Block Variation
+ *
+ * Registers a block variation for accommodation check-out time display.
+ * Only available on accommodation post type edit screens.
+ *
+ * @since 2.1.0
+ * @package Tour_Operator
+ */
+
+
 wp.domReady(() => {
   const {
     select
@@ -39,7 +137,7 @@ wp.domReady(() => {
           iconType: "solid",
           iconName: "checkInAccommodationIcon"
         }], ["core/paragraph", {
-          content: "<strong>Check out time:</strong>"
+          content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check out time:', 'tour-operator')
         }]]], ["core/group", {
           layout: {
             type: "flex",
@@ -70,7 +168,7 @@ wp.domReady(() => {
             content: "Check Out Time",
             level: 3
           }], ["core/paragraph", {
-            content: "11:00 AM"
+            content: "3:00 PM"
           }]]]]
         }
       });
@@ -92,6 +190,7 @@ wp.domReady(() => {
     setTimeout(() => clearInterval(interval), 5000);
   }
 });
+}();
 /******/ })()
 ;
 //# sourceMappingURL=index.js.map

--- a/build/blocks/checkout-time/index.js
+++ b/build/blocks/checkout-time/index.js
@@ -100,6 +100,77 @@ __webpack_require__.r(__webpack_exports__);
  */
 
 
+function registerCheckoutTimeVariation() {
+  try {
+    wp.blocks.registerBlockVariation("core/group", {
+      name: "lsx-tour-operator/checkout-time",
+      title: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)("Check out time", "tour-operator"),
+      icon: "clock",
+      category: "lsx-tour-operator",
+      isActive: (blockAttributes, variationAttributes) => {
+        return blockAttributes.metadata?.name === variationAttributes.metadata?.name;
+      },
+      attributes: {
+        metadata: {
+          name: "Check out time"
+        },
+        className: "lsx-checkout-time-wrapper",
+        layout: {
+          type: "flex",
+          flexWrap: "nowrap"
+        }
+      },
+      innerBlocks: [["core/group", {
+        layout: {
+          type: "flex",
+          flexWrap: "nowrap",
+          verticalAlignment: "middle"
+        }
+      }, [["lsx-tour-operator/icons", {
+        iconType: "solid",
+        iconName: "checkInAccommodationIcon"
+      }], ["core/paragraph", {
+        content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check out time:', 'tour-operator')
+      }]]], ["core/group", {
+        layout: {
+          type: "flex",
+          flexWrap: "nowrap"
+        }
+      }, [["core/paragraph", {
+        metadata: {
+          bindings: {
+            content: {
+              source: "lsx/post-meta",
+              args: {
+                key: "checkout_time"
+              }
+            }
+          }
+        }
+      }]]]],
+      supports: {
+        renaming: false
+      },
+      example: {
+        attributes: {
+          metadata: {
+            name: "Check Out Time"
+          }
+        },
+        innerBlocks: [["core/group", {}, [["core/heading", {
+          content: "Check Out Time",
+          level: 3
+        }], ["core/paragraph", {
+          content: "3:00 PM"
+        }]]]]
+      }
+    });
+    return true;
+  } catch (error) {
+    console.error('Failed to register checkout-time block:', error);
+    return false;
+  }
+}
 wp.domReady(() => {
   const {
     select
@@ -107,74 +178,23 @@ wp.domReady(() => {
 
   // Define supported post types
   const supportedPostTypes = ['accommodation'];
+  let registered = false;
 
   // Check if current post type is supported
   const checkAndRegister = () => {
-    const postType = select('core/editor')?.getCurrentPostType();
-    if (postType && supportedPostTypes.includes(postType)) {
-      wp.blocks.registerBlockVariation("core/group", {
-        name: "lsx-tour-operator/checkout-time",
-        title: "Check Out Time",
-        icon: "clock",
-        category: "lsx-tour-operator",
-        attributes: {
-          metadata: {
-            name: "Check Out Time"
-          },
-          className: "lsx-checkout-time-wrapper",
-          layout: {
-            type: "flex",
-            flexWrap: "nowrap"
-          }
-        },
-        innerBlocks: [["core/group", {
-          layout: {
-            type: "flex",
-            flexWrap: "nowrap",
-            verticalAlignment: "middle"
-          }
-        }, [["lsx-tour-operator/icons", {
-          iconType: "solid",
-          iconName: "checkInAccommodationIcon"
-        }], ["core/paragraph", {
-          content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)('Check out time:', 'tour-operator')
-        }]]], ["core/group", {
-          layout: {
-            type: "flex",
-            flexWrap: "nowrap"
-          }
-        }, [["core/paragraph", {
-          metadata: {
-            bindings: {
-              content: {
-                source: "lsx/post-meta",
-                args: {
-                  key: "checkout_time"
-                }
-              }
-            }
-          }
-        }]]]],
-        supports: {
-          renaming: false
-        },
-        example: {
-          attributes: {
-            metadata: {
-              name: "Check Out Time"
-            }
-          },
-          innerBlocks: [["core/group", {}, [["core/heading", {
-            content: "Check Out Time",
-            level: 3
-          }], ["core/paragraph", {
-            content: "3:00 PM"
-          }]]]]
-        }
-      });
-      return true; // Registration successful
+    if (registered) {
+      return true;
     }
-    return false; // Post type not ready or not supported
+    const postType = select('core/editor')?.getCurrentPostType();
+    const postSlug = select('core/editor')?.getEditedPostSlug();
+    if (!postType || !postSlug) {
+      return false;
+    }
+    if (supportedPostTypes.includes(postType) || (postType === 'wp_template' || postType === 'wp_template_part') && postSlug.includes('accommodation')) {
+      registerCheckoutTimeVariation();
+      registered = true;
+    }
+    return registered;
   };
 
   // Try immediate registration

--- a/build/blocks/checkout-time/index.js
+++ b/build/blocks/checkout-time/index.js
@@ -112,7 +112,7 @@ function registerCheckoutTimeVariation() {
       },
       attributes: {
         metadata: {
-          name: "Check out time"
+          name: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)("Check out time", "tour-operator")
         },
         className: "lsx-checkout-time-wrapper",
         layout: {
@@ -154,11 +154,11 @@ function registerCheckoutTimeVariation() {
       example: {
         attributes: {
           metadata: {
-            name: "Check Out Time"
+            name: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)("Check Out Time", "tour-operator")
           }
         },
         innerBlocks: [["core/group", {}, [["core/heading", {
-          content: "Check Out Time",
+          content: (0,_wordpress_i18n__WEBPACK_IMPORTED_MODULE_0__.__)("Check Out Time", "tour-operator"),
           level: 3
         }], ["core/paragraph", {
           content: "3:00 PM"

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 - Removing the debug statements, A filter to allow the disabling of destinations when searching for related content. Prepping the registration for the adjust block registration. Refactoring the query statments into seperate functions. Fixing the filters for the related connections - PR (#486)
 - Added Related post connections to the single posts. - [#595](https://github.com/lightspeedwp/tour-operator/issues/595)
 - Added in the TO Videos block to display your Youtube videos in a gallery type output. [#598](https://github.com/lightspeedwp/tour-operator/pull/598)
+- Added icon block icons instead of images for checkin/checkout time blocks, as well as a filter so they appear only on relevant post types (accommodation) and related templates/template parts [#645](https://github.com/lightspeedwp/tour-operator/pull/645)
 
 ### Integrations
 - Added integration with the Action Scheduler to allow Tours to expire and be set to draft [#490](https://github.com/lightspeedwp/tour-operator/pull/490). Work with any plugin using the Action Scheduler as a vendor [WooCommerce](https://woocommerce.com/), [PublishPress](https://publishpress.com/), [Action Scheduler](https://wordpress.org/plugins/action-scheduler/).

--- a/src/blocks/checkin-time/block.json
+++ b/src/blocks/checkin-time/block.json
@@ -34,7 +34,7 @@
           [
             "core/paragraph",
             {
-              "content": "3:00 PM"
+              "content": "11:00 AM"
             }
           ]
         ]

--- a/src/blocks/checkin-time/block.json
+++ b/src/blocks/checkin-time/block.json
@@ -1,8 +1,44 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
+  "textdomain": "tour-operator",
   "name": "lsx-tour-operator/checkin-time",
   "title": "Check In Time",
   "category": "lsx-tour-operator",
-  "editorScript": "file:index.js"
+  "editorScript": "file:index.js",
+  "description": "Show accommodation check-in time and procedures.",
+  "icon": "clock",
+  "keywords": [
+    "checkin",
+    "time",
+    "arrival"
+  ],
+  "example": {
+    "attributes": {
+      "metadata": {
+        "name": "Check In Time"
+      }
+    },
+    "innerBlocks": [
+      [
+        "core/group",
+        {},
+        [
+          [
+            "core/heading",
+            {
+              "content": "Check In Time",
+              "level": 3
+            }
+          ],
+          [
+            "core/paragraph",
+            {
+              "content": "3:00 PM"
+            }
+          ]
+        ]
+      ]
+    ]
+  }
 }

--- a/src/blocks/checkin-time/index.js
+++ b/src/blocks/checkin-time/index.js
@@ -22,7 +22,7 @@ function registerCheckinTimeVariation() {
             },
             attributes: {
                 metadata: {
-                    name: 'Check in time',
+                    name: __('Check in time', 'tour-operator'),
                 },
                 className: 'lsx-checkin-time-wrapper',
                 layout: {
@@ -92,7 +92,7 @@ function registerCheckinTimeVariation() {
             example: {
                 attributes: {
                     metadata: {
-                        name: 'Check in time',
+                        name: __('Check in time', 'tour-operator'),
                     },
                 },
                 innerBlocks: [
@@ -103,7 +103,7 @@ function registerCheckinTimeVariation() {
                             [
                                 'core/heading',
                                 {
-                                    content: 'Check in time',
+                                    content: __('Check in time', 'tour-operator'),
                                     level: 3,
                                 },
                             ],

--- a/src/blocks/checkin-time/index.js
+++ b/src/blocks/checkin-time/index.js
@@ -1,3 +1,15 @@
+/**
+ * Check Out Time Block Variation
+ *
+ * Registers a block variation for accommodation check-out time display.
+ * Only available on accommodation post type edit screens.
+ *
+ * @since 2.1.0
+ * @package Tour_Operator
+ */
+
+import { __ } from '@wordpress/i18n';
+
 wp.domReady(() => {
     const { select } = wp.data;
 
@@ -45,7 +57,10 @@ wp.domReady(() => {
                             [
                                 "core/paragraph",
                                 {
-                                    content: "<strong>Check in time:</strong>",
+                                    content: __(
+                                        'Check in time:',
+                                        'tour-operator'
+                                    ),
                                 },
                             ],
                         ],
@@ -101,7 +116,7 @@ wp.domReady(() => {
                                 [
                                     "core/paragraph",
                                     {
-                                        content: "3:00 PM",
+                                        content: "11:00 AM",
                                     },
                                 ],
                             ],

--- a/src/blocks/checkin-time/index.js
+++ b/src/blocks/checkin-time/index.js
@@ -1,7 +1,7 @@
 /**
- * Check Out Time Block Variation
+ * Check In Time Block Variation
  *
- * Registers a block variation for accommodation check-out time display.
+ * Registers a block variation for accommodation check-in time display.
  * Only available on accommodation post type edit screens.
  *
  * @since 2.1.0

--- a/src/blocks/checkin-time/index.js
+++ b/src/blocks/checkin-time/index.js
@@ -10,123 +10,147 @@
 
 import { __ } from '@wordpress/i18n';
 
-wp.domReady(() => {
-    const { select } = wp.data;
-
-    // Define supported post types
-    const supportedPostTypes = ['accommodation'];
-
-    // Check if current post type is supported
-    const checkAndRegister = () => {
-        const postType = select('core/editor')?.getCurrentPostType();
-
-        if (postType && supportedPostTypes.includes(postType)) {
-            wp.blocks.registerBlockVariation("core/group", {
-                name: "lsx-tour-operator/checkin-time",
-                title: "Check In Time",
-                icon: "clock",
-                category: "lsx-tour-operator",
+function registerCheckinTimeVariation() {
+    try {
+        wp.blocks.registerBlockVariation('core/group', {
+            name: 'lsx-tour-operator/checkin-time',
+            title: __('Check in time', 'tour-operator'),
+            icon: 'clock',
+            category: 'lsx-tour-operator',
+            isActive: (blockAttributes, variationAttributes) => {
+                return blockAttributes.metadata?.name === variationAttributes.metadata?.name;
+            },
+            attributes: {
+                metadata: {
+                    name: 'Check in time',
+                },
+                className: 'lsx-checkin-time-wrapper',
+                layout: {
+                    type: 'flex',
+                    flexWrap: 'nowrap',
+                },
+            },
+            innerBlocks: [
+                [
+                    'core/group',
+                    {
+                        layout: {
+                            type: 'flex',
+                            flexWrap: 'nowrap',
+                            verticalAlignment: 'middle',
+                        },
+                    },
+                    [
+                        [
+                            'lsx-tour-operator/icons',
+                            {
+                                iconType: 'solid',
+                                iconName: 'checkInAccommodationIcon',
+                            },
+                        ],
+                        [
+                            'core/paragraph',
+                            {
+                                content: __(
+                                    'Check in time:',
+                                    'tour-operator'
+                                ),
+                            },
+                        ],
+                    ],
+                ],
+                [
+                    'core/group',
+                    {
+                        layout: {
+                            type: 'flex',
+                            flexWrap: 'nowrap',
+                        },
+                    },
+                    [
+                        [
+                            'core/paragraph',
+                            {
+                                metadata: {
+                                    bindings: {
+                                        content: {
+                                            source: 'lsx/post-meta',
+                                            args: {
+                                                key: 'checkin_time',
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    ],
+                ],
+            ],
+            supports: {
+                renaming: false,
+            },
+            example: {
                 attributes: {
                     metadata: {
-                        name: "Check In Time",
-                    },
-                    className: "lsx-checkin-time-wrapper",
-                    layout: {
-                        type: "flex",
-                        flexWrap: "nowrap",
+                        name: 'Check in time',
                     },
                 },
                 innerBlocks: [
                     [
-                        "core/group",
-                        {
-                            layout: {
-                                type: "flex",
-                                flexWrap: "nowrap",
-                                verticalAlignment: "middle",
-                            },
-                        },
+                        'core/group',
+                        {},
                         [
                             [
-                                "lsx-tour-operator/icons",
+                                'core/heading',
                                 {
-                                    iconType: "solid",
-                                    iconName: "checkInAccommodationIcon",
+                                    content: 'Check in time',
+                                    level: 3,
                                 },
                             ],
                             [
-                                "core/paragraph",
+                                'core/paragraph',
                                 {
-                                    content: __(
-                                        'Check in time:',
-                                        'tour-operator'
-                                    ),
-                                },
-                            ],
-                        ],
-                    ],
-                    [
-                        "core/group",
-                        {
-                            layout: {
-                                type: "flex",
-                                flexWrap: "nowrap",
-                            },
-                        },
-                        [
-                            [
-                                "core/paragraph",
-                                {
-                                    metadata: {
-                                        bindings: {
-                                            content: {
-                                                source: "lsx/post-meta",
-                                                args: {
-                                                    key: "checkin_time",
-                                                },
-                                            },
-                                        },
-                                    },
+                                    content: '11:00 AM',
                                 },
                             ],
                         ],
                     ],
                 ],
-                supports: {
-                    renaming: false,
-                },
-                example: {
-                    attributes: {
-                        metadata: {
-                            name: "Check In Time",
-                        },
-                    },
-                    innerBlocks: [
-                        [
-                            "core/group",
-                            {},
-                            [
-                                [
-                                    "core/heading",
-                                    {
-                                        content: "Check In Time",
-                                        level: 3,
-                                    },
-                                ],
-                                [
-                                    "core/paragraph",
-                                    {
-                                        content: "11:00 AM",
-                                    },
-                                ],
-                            ],
-                        ],
-                    ],
-                },
-            });
-            return true; // Registration successful
+            },
+        });
+        return true;
+    } catch (error) {
+        console.error('Failed to register checkin-time block:', error);
+        return false;
+    }
+}
+
+wp.domReady(() => {
+    const { select } = wp.data;
+
+    // Define supported post types
+    const supportedPostTypes = ['accommodation'];
+    let registered = false;
+
+    // Check if current post type is supported
+    const checkAndRegister = () => {
+        if (registered) {
+            return true;
         }
-        return false; // Post type not ready or not supported
+
+        const postType = select('core/editor')?.getCurrentPostType();
+        const postSlug = select('core/editor')?.getEditedPostSlug();
+
+        if (!postType || !postSlug) {
+            return false;
+        }
+
+        if (supportedPostTypes.includes(postType) || ((postType === 'wp_template' || postType === 'wp_template_part') && postSlug.includes('accommodation'))) {
+            registerCheckinTimeVariation();
+            registered = true;
+        }
+
+        return registered;
     };
 
     // Try immediate registration

--- a/src/blocks/checkin-time/index.js
+++ b/src/blocks/checkin-time/index.js
@@ -1,82 +1,129 @@
-wp.domReady( () => {
-    wp.blocks.registerBlockVariation( 'core/group', {
-        name: 'lsx-tour-operator/checkin-time',
-        title: 'Check In Time',
-        icon: 'clock',
-        category: 'lsx-tour-operator',
-        attributes: {
-            metadata: {
-                name: 'Check In Time',
-            },
-            className: 'lsx-checkin-time-wrapper',
+wp.domReady(() => {
+    const { select } = wp.data;
 
-            layout: {
-                type: 'flex',
-                flexWrap: 'nowrap',
-            },
-        },
-        innerBlocks: [
-            [
-                'core/group',
-                {
+    // Define supported post types
+    const supportedPostTypes = ['accommodation'];
+
+    // Check if current post type is supported
+    const checkAndRegister = () => {
+        const postType = select('core/editor')?.getCurrentPostType();
+
+        if (postType && supportedPostTypes.includes(postType)) {
+            wp.blocks.registerBlockVariation("core/group", {
+                name: "lsx-tour-operator/checkin-time",
+                title: "Check In Time",
+                icon: "clock",
+                category: "lsx-tour-operator",
+                attributes: {
+                    metadata: {
+                        name: "Check In Time",
+                    },
+                    className: "lsx-checkin-time-wrapper",
                     layout: {
-                        type: 'flex',
-                        flexWrap: 'nowrap',
-                        verticalAlignment: 'top',
+                        type: "flex",
+                        flexWrap: "nowrap",
                     },
                 },
-                [
+                innerBlocks: [
                     [
-                        'core/image',
+                        "core/group",
                         {
-                            id: 122720,
-                            width: '20px',
-                            sizeSlug: 'large',
-                            linkDestination: 'none',
-                            url:
-                                lsxToEditor.assetsUrl +
-                                'blocks/check-in-check-out-time.svg',
-                            alt: '',
-                            className: 'wp-image-122720',
+                            layout: {
+                                type: "flex",
+                                flexWrap: "nowrap",
+                                verticalAlignment: "middle",
+                            },
                         },
+                        [
+                            [
+                                "lsx-tour-operator/icons",
+                                {
+                                    iconType: "solid",
+                                    iconName: "checkInAccommodationIcon",
+                                },
+                            ],
+                            [
+                                "core/paragraph",
+                                {
+                                    content: "<strong>Check in time:</strong>",
+                                },
+                            ],
+                        ],
                     ],
                     [
-                        'core/paragraph',
+                        "core/group",
                         {
-                            content: '<strong>Check in time:</strong>',
+                            layout: {
+                                type: "flex",
+                                flexWrap: "nowrap",
+                            },
                         },
-                    ],
-                ],
-            ],
-            [
-                'core/group',
-                {
-                    layout: {
-                        type: 'flex',
-                        flexWrap: 'nowrap',
-                    },
-                },
-                [
-                    [
-                        'core/paragraph',
-                        {
-                            metadata: {
-                                bindings: {
-                                    content: {
-                                        source: 'lsx/post-meta',
-                                        args: {
-                                            key: 'checkin_time',
+                        [
+                            [
+                                "core/paragraph",
+                                {
+                                    metadata: {
+                                        bindings: {
+                                            content: {
+                                                source: "lsx/post-meta",
+                                                args: {
+                                                    key: "checkin_time",
+                                                },
+                                            },
                                         },
                                     },
                                 },
-                            },
-                        },
+                            ],
+                        ],
                     ],
                 ],
-            ],
-        ],
-        supports: {
-            renaming: false,
-        },
-    } );
-} );
+                supports: {
+                    renaming: false,
+                },
+                example: {
+                    attributes: {
+                        metadata: {
+                            name: "Check In Time",
+                        },
+                    },
+                    innerBlocks: [
+                        [
+                            "core/group",
+                            {},
+                            [
+                                [
+                                    "core/heading",
+                                    {
+                                        content: "Check In Time",
+                                        level: 3,
+                                    },
+                                ],
+                                [
+                                    "core/paragraph",
+                                    {
+                                        content: "3:00 PM",
+                                    },
+                                ],
+                            ],
+                        ],
+                    ],
+                },
+            });
+            return true; // Registration successful
+        }
+        return false; // Post type not ready or not supported
+    };
+
+    // Try immediate registration
+    if (!checkAndRegister()) {
+        // If not ready, check periodically
+        const interval = setInterval(() => {
+            if (checkAndRegister()) {
+                clearInterval(interval);
+            }
+        }, 100);
+
+        // Clean up after 5 seconds to prevent infinite checking
+        setTimeout(() => clearInterval(interval), 5000);
+    }
+});

--- a/src/blocks/checkout-time/block.json
+++ b/src/blocks/checkout-time/block.json
@@ -1,8 +1,44 @@
 {
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
+  "textdomain": "tour-operator",
   "name": "lsx-tour-operator/checkout-time",
   "title": "Check Out Time",
   "category": "lsx-tour-operator",
-  "editorScript": "file:index.js"
+  "editorScript": "file:index.js",
+  "description": "Show accommodation check-out time and procedures.",
+  "icon": "clock",
+  "keywords": [
+    "checkout",
+    "time",
+    "departure"
+  ],
+  "example": {
+    "attributes": {
+      "metadata": {
+        "name": "Check Out Time"
+      }
+    },
+    "innerBlocks": [
+      [
+        "core/group",
+        {},
+        [
+          [
+            "core/heading",
+            {
+              "content": "Check Out Time",
+              "level": 3
+            }
+          ],
+          [
+            "core/paragraph",
+            {
+              "content": "11:00 AM"
+            }
+          ]
+        ]
+      ]
+    ]
+  }
 }

--- a/src/blocks/checkout-time/block.json
+++ b/src/blocks/checkout-time/block.json
@@ -34,7 +34,7 @@
           [
             "core/paragraph",
             {
-              "content": "11:00 AM"
+              "content": "3:00 PM"
             }
           ]
         ]

--- a/src/blocks/checkout-time/index.js
+++ b/src/blocks/checkout-time/index.js
@@ -22,7 +22,7 @@ function registerCheckoutTimeVariation() {
             },
             attributes: {
                 metadata: {
-                    name: "Check out time",
+                    name: __("Check out time", "tour-operator"),
                 },
                 className: "lsx-checkout-time-wrapper",
                 layout: {
@@ -92,7 +92,7 @@ function registerCheckoutTimeVariation() {
             example: {
                 attributes: {
                     metadata: {
-                        name: "Check Out Time",
+                        name: __("Check Out Time", "tour-operator"),
                     },
                 },
                 innerBlocks: [
@@ -103,7 +103,7 @@ function registerCheckoutTimeVariation() {
                             [
                                 "core/heading",
                                 {
-                                    content: "Check Out Time",
+                                    content: __("Check Out Time", "tour-operator"),
                                     level: 3,
                                 },
                             ],

--- a/src/blocks/checkout-time/index.js
+++ b/src/blocks/checkout-time/index.js
@@ -1,3 +1,15 @@
+/**
+ * Check Out Time Block Variation
+ *
+ * Registers a block variation for accommodation check-out time display.
+ * Only available on accommodation post type edit screens.
+ *
+ * @since 2.1.0
+ * @package Tour_Operator
+ */
+
+import { __ } from '@wordpress/i18n';
+
 wp.domReady(() => {
     const { select } = wp.data;
 
@@ -45,7 +57,10 @@ wp.domReady(() => {
                             [
                                 "core/paragraph",
                                 {
-                                    content: "<strong>Check out time:</strong>",
+                                    content: __(
+                                        'Check out time:',
+                                        'tour-operator'
+                                    ),
                                 },
                             ],
                         ],
@@ -101,7 +116,7 @@ wp.domReady(() => {
                                 [
                                     "core/paragraph",
                                     {
-                                        content: "11:00 AM",
+                                        content: "3:00 PM",
                                     },
                                 ],
                             ],

--- a/src/blocks/checkout-time/index.js
+++ b/src/blocks/checkout-time/index.js
@@ -1,82 +1,129 @@
-wp.domReady( () => {
-    wp.blocks.registerBlockVariation( 'core/group', {
-        name: 'lsx-tour-operator/checkout-time',
-        title: 'Check Out Time',
-        icon: 'clock',
-        category: 'lsx-tour-operator',
-        attributes: {
-            metadata: {
-                name: 'Check Out Time',
-            },
-            className: 'lsx-checkout-time-wrapper',
+wp.domReady(() => {
+    const { select } = wp.data;
 
-            layout: {
-                type: 'flex',
-                flexWrap: 'nowrap',
-            },
-        },
-        innerBlocks: [
-            [
-                'core/group',
-                {
+    // Define supported post types
+    const supportedPostTypes = ['accommodation'];
+
+    // Check if current post type is supported
+    const checkAndRegister = () => {
+        const postType = select('core/editor')?.getCurrentPostType();
+
+        if (postType && supportedPostTypes.includes(postType)) {
+            wp.blocks.registerBlockVariation("core/group", {
+                name: "lsx-tour-operator/checkout-time",
+                title: "Check Out Time",
+                icon: "clock",
+                category: "lsx-tour-operator",
+                attributes: {
+                    metadata: {
+                        name: "Check Out Time",
+                    },
+                    className: "lsx-checkout-time-wrapper",
                     layout: {
-                        type: 'flex',
-                        flexWrap: 'nowrap',
-                        verticalAlignment: 'top',
+                        type: "flex",
+                        flexWrap: "nowrap",
                     },
                 },
-                [
+                innerBlocks: [
                     [
-                        'core/image',
+                        "core/group",
                         {
-                            id: 122720,
-                            width: '20px',
-                            sizeSlug: 'large',
-                            linkDestination: 'none',
-                            url:
-                                lsxToEditor.assetsUrl +
-                                'blocks/check-in-check-out-time.svg',
-                            alt: '',
-                            className: 'wp-image-122720',
+                            layout: {
+                                type: "flex",
+                                flexWrap: "nowrap",
+                                verticalAlignment: "middle",
+                            },
                         },
+                        [
+                            [
+                                "lsx-tour-operator/icons",
+                                {
+                                    iconType: "solid",
+                                    iconName: "checkInAccommodationIcon",
+                                },
+                            ],
+                            [
+                                "core/paragraph",
+                                {
+                                    content: "<strong>Check out time:</strong>",
+                                },
+                            ],
+                        ],
                     ],
                     [
-                        'core/paragraph',
+                        "core/group",
                         {
-                            content: '<strong>Check out time:</strong>',
+                            layout: {
+                                type: "flex",
+                                flexWrap: "nowrap",
+                            },
                         },
-                    ],
-                ],
-            ],
-            [
-                'core/group',
-                {
-                    layout: {
-                        type: 'flex',
-                        flexWrap: 'nowrap',
-                    },
-                },
-                [
-                    [
-                        'core/paragraph',
-                        {
-                            metadata: {
-                                bindings: {
-                                    content: {
-                                        source: 'lsx/post-meta',
-                                        args: {
-                                            key: 'checkout_time',
+                        [
+                            [
+                                "core/paragraph",
+                                {
+                                    metadata: {
+                                        bindings: {
+                                            content: {
+                                                source: "lsx/post-meta",
+                                                args: {
+                                                    key: "checkout_time",
+                                                },
+                                            },
                                         },
                                     },
                                 },
-                            },
-                        },
+                            ],
+                        ],
                     ],
                 ],
-            ],
-        ],
-        supports: {
-            renaming: false,
-        },
-    } );
-} );
+                supports: {
+                    renaming: false,
+                },
+                example: {
+                    attributes: {
+                        metadata: {
+                            name: "Check Out Time",
+                        },
+                    },
+                    innerBlocks: [
+                        [
+                            "core/group",
+                            {},
+                            [
+                                [
+                                    "core/heading",
+                                    {
+                                        content: "Check Out Time",
+                                        level: 3,
+                                    },
+                                ],
+                                [
+                                    "core/paragraph",
+                                    {
+                                        content: "11:00 AM",
+                                    },
+                                ],
+                            ],
+                        ],
+                    ],
+                },
+            });
+            return true; // Registration successful
+        }
+        return false; // Post type not ready or not supported
+    };
+
+    // Try immediate registration
+    if (!checkAndRegister()) {
+        // If not ready, check periodically
+        const interval = setInterval(() => {
+            if (checkAndRegister()) {
+                clearInterval(interval);
+            }
+        }, 100);
+
+        // Clean up after 5 seconds to prevent infinite checking
+        setTimeout(() => clearInterval(interval), 5000);
+    }
+});

--- a/src/blocks/checkout-time/index.js
+++ b/src/blocks/checkout-time/index.js
@@ -10,123 +10,147 @@
 
 import { __ } from '@wordpress/i18n';
 
-wp.domReady(() => {
-    const { select } = wp.data;
-
-    // Define supported post types
-    const supportedPostTypes = ['accommodation'];
-
-    // Check if current post type is supported
-    const checkAndRegister = () => {
-        const postType = select('core/editor')?.getCurrentPostType();
-
-        if (postType && supportedPostTypes.includes(postType)) {
-            wp.blocks.registerBlockVariation("core/group", {
-                name: "lsx-tour-operator/checkout-time",
-                title: "Check Out Time",
-                icon: "clock",
-                category: "lsx-tour-operator",
+function registerCheckoutTimeVariation() {
+    try {
+        wp.blocks.registerBlockVariation("core/group", {
+            name: "lsx-tour-operator/checkout-time",
+            title: __("Check out time", "tour-operator"),
+            icon: "clock",
+            category: "lsx-tour-operator",
+            isActive: (blockAttributes, variationAttributes) => {
+                return blockAttributes.metadata?.name === variationAttributes.metadata?.name;
+            },
+            attributes: {
+                metadata: {
+                    name: "Check out time",
+                },
+                className: "lsx-checkout-time-wrapper",
+                layout: {
+                    type: "flex",
+                    flexWrap: "nowrap",
+                },
+            },
+            innerBlocks: [
+                [
+                    "core/group",
+                    {
+                        layout: {
+                            type: "flex",
+                            flexWrap: "nowrap",
+                            verticalAlignment: "middle",
+                        },
+                    },
+                    [
+                        [
+                            "lsx-tour-operator/icons",
+                            {
+                                iconType: "solid",
+                                iconName: "checkInAccommodationIcon",
+                            },
+                        ],
+                        [
+                            "core/paragraph",
+                            {
+                                content: __(
+                                    'Check out time:',
+                                    'tour-operator'
+                                ),
+                            },
+                        ],
+                    ],
+                ],
+                [
+                    "core/group",
+                    {
+                        layout: {
+                            type: "flex",
+                            flexWrap: "nowrap",
+                        },
+                    },
+                    [
+                        [
+                            "core/paragraph",
+                            {
+                                metadata: {
+                                    bindings: {
+                                        content: {
+                                            source: "lsx/post-meta",
+                                            args: {
+                                                key: "checkout_time",
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                    ],
+                ],
+            ],
+            supports: {
+                renaming: false,
+            },
+            example: {
                 attributes: {
                     metadata: {
                         name: "Check Out Time",
-                    },
-                    className: "lsx-checkout-time-wrapper",
-                    layout: {
-                        type: "flex",
-                        flexWrap: "nowrap",
                     },
                 },
                 innerBlocks: [
                     [
                         "core/group",
-                        {
-                            layout: {
-                                type: "flex",
-                                flexWrap: "nowrap",
-                                verticalAlignment: "middle",
-                            },
-                        },
+                        {},
                         [
                             [
-                                "lsx-tour-operator/icons",
+                                "core/heading",
                                 {
-                                    iconType: "solid",
-                                    iconName: "checkInAccommodationIcon",
+                                    content: "Check Out Time",
+                                    level: 3,
                                 },
                             ],
                             [
                                 "core/paragraph",
                                 {
-                                    content: __(
-                                        'Check out time:',
-                                        'tour-operator'
-                                    ),
-                                },
-                            ],
-                        ],
-                    ],
-                    [
-                        "core/group",
-                        {
-                            layout: {
-                                type: "flex",
-                                flexWrap: "nowrap",
-                            },
-                        },
-                        [
-                            [
-                                "core/paragraph",
-                                {
-                                    metadata: {
-                                        bindings: {
-                                            content: {
-                                                source: "lsx/post-meta",
-                                                args: {
-                                                    key: "checkout_time",
-                                                },
-                                            },
-                                        },
-                                    },
+                                    content: "3:00 PM",
                                 },
                             ],
                         ],
                     ],
                 ],
-                supports: {
-                    renaming: false,
-                },
-                example: {
-                    attributes: {
-                        metadata: {
-                            name: "Check Out Time",
-                        },
-                    },
-                    innerBlocks: [
-                        [
-                            "core/group",
-                            {},
-                            [
-                                [
-                                    "core/heading",
-                                    {
-                                        content: "Check Out Time",
-                                        level: 3,
-                                    },
-                                ],
-                                [
-                                    "core/paragraph",
-                                    {
-                                        content: "3:00 PM",
-                                    },
-                                ],
-                            ],
-                        ],
-                    ],
-                },
-            });
-            return true; // Registration successful
+            },
+        });
+        return true;
+    } catch (error) {
+        console.error('Failed to register checkout-time block:', error);
+        return false;
+    }
+}
+
+wp.domReady(() => {
+    const { select } = wp.data;
+
+    // Define supported post types
+    const supportedPostTypes = ['accommodation'];
+    let registered = false;
+
+    // Check if current post type is supported
+    const checkAndRegister = () => {
+        if (registered) {
+            return true;
         }
-        return false; // Post type not ready or not supported
+
+        const postType = select('core/editor')?.getCurrentPostType();
+        const postSlug = select('core/editor')?.getEditedPostSlug();
+
+        if (!postType || !postSlug) {
+            return false;
+        }
+
+        if (supportedPostTypes.includes(postType) || ((postType === 'wp_template' || postType === 'wp_template_part') && postSlug.includes('accommodation'))) {
+            registerCheckoutTimeVariation();
+            registered = true;
+        }
+
+        return registered;
     };
 
     // Try immediate registration

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -30,11 +30,8 @@ define('LSX_TO_URL', plugin_dir_url(__FILE__));
 define('LSX_TO_VER', '2.1.0');
 
 // Maintain a list of content model JSON paths consumed by the plugin.
-global $lsx_to_content_model_json_path;
-if (! is_array($lsx_to_content_model_json_path)) {
-	$lsx_to_content_model_json_path = array();
-}
-$lsx_to_content_model_json_path[] = LSX_TO_PATH;
+global $CONTENT_MODEL_JSON_PATH;
+$CONTENT_MODEL_JSON_PATH[] = LSX_TO_PATH;
 
 // Post Expirator.
 define('LSX_TO_POSTEXPIRATOR_DATEFORMAT', esc_html__('l F jS, Y', 'tour-operator'));

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -30,8 +30,10 @@ define('LSX_TO_URL', plugin_dir_url(__FILE__));
 define('LSX_TO_VER', '2.1.0');
 
 // Maintain a list of content model JSON paths consumed by the plugin.
+// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
 global $CONTENT_MODEL_JSON_PATH;
 $CONTENT_MODEL_JSON_PATH[] = LSX_TO_PATH;
+// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 // Post Expirator.
 define('LSX_TO_POSTEXPIRATOR_DATEFORMAT', esc_html__('l F jS, Y', 'tour-operator'));


### PR DESCRIPTION
---
pr: 645
related_issues:
  - 644
blocks:
  - lsx/checkin-time
  - lsx/checkout-time
post_types:
  - accommodation
author: tibiii
labels:
  - enhancement
  - block
  - audit
---

## Summary
This pull request updates both the Check In Time and Check Out Time block variations for the LSX Tour Operator plugin, making them more descriptive, context-aware, and visually consistent. The changes ensure the blocks only register for the `accommodation` post type, add richer metadata and examples, and switch to a custom icon component for improved branding.

Block registration improvements:

* Both `checkin-time` and `checkout-time` block variations now register only when editing an `accommodation` post type, using a polling mechanism to ensure correct timing. [[1]](diffhunk://#diff-03e2ffa42a0f603db3109211fb112aef77b5173aa7eea62192f9496ab7630bc0L2-R70) [[2]](diffhunk://#diff-ca0d438bfc80f02cef0b501b2e8e7d9916bff8336a05da5676932a9044d02565L2-R70)
* The icon for both blocks is changed from a static image to the custom `lsx-tour-operator/icons` block with `checkInAccommodationIcon`, improving consistency and maintainability. [[1]](diffhunk://#diff-03e2ffa42a0f603db3109211fb112aef77b5173aa7eea62192f9496ab7630bc0L2-R70) [[2]](diffhunk://#diff-ca0d438bfc80f02cef0b501b2e8e7d9916bff8336a05da5676932a9044d02565L2-R70)

Block configuration enhancements:

* Added `description`, `icon`, `keywords`, and a detailed `example` to both `block.json` files, improving discoverability and usability in the block editor. [[1]](diffhunk://#diff-b5e2f161b97730fb892688482970de4b43157c89fa75930ba00b14a833f1f346R4-R43) [[2]](diffhunk://#diff-9422c80c827d810a9c2a2e6c56591c01714d0e44977e178e5b6cf1f6b19a1900R4-R43)
* The block examples now show a heading and sample time, providing a clearer preview in the editor. [[1]](diffhunk://#diff-b5e2f161b97730fb892688482970de4b43157c89fa75930ba00b14a833f1f346R4-R43) [[2]](diffhunk://#diff-9422c80c827d810a9c2a2e6c56591c01714d0e44977e178e5b6cf1f6b19a1900R4-R43)

Technical and metadata updates:

* Added a `textdomain` field to both block configurations for proper localization support. [[1]](diffhunk://#diff-b5e2f161b97730fb892688482970de4b43157c89fa75930ba00b14a833f1f346R4-R43) [[2]](diffhunk://#diff-9422c80c827d810a9c2a2e6c56591c01714d0e44977e178e5b6cf1f6b19a1900R4-R43)
* Updated asset version hashes in the PHP asset files to reflect the new builds. [[1]](diffhunk://#diff-9dc533a8859923daf6892f6e3d95b2ab22b2634de43681536bd42c2343ce4f4fL1-R1) [[2]](diffhunk://#diff-33d3fa10bf17104f02baac4d6bc91e361478a62ce3a98852dc1d4eb890c9e78aL1-R1)…d improved registration logic
## Scope
- [x] PHP
- [x] JS/Blocks
- [ ] Styles (theme.json / selectors)
- [ ] Tests (Playwright)
- [ ] Docs

## Screenshots / Videos
_If relevant._

## Checklist
- [x] Block API v3
- [x] `block.json` updated (title, description, keywords, supports, example, selectors)
- [ ] Registered via PHP using metadata
- [ ] Theme.json styles (no bespoke CSS unless unavoidable)
- [x] Preview works in inserter
- [ ] E2E tests added/updated

## Related issues
This closes #644 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Check‑in and Check‑out blocks with icons, translated labels, nested grouped layouts and example previews.

* **Improvements**
  * Blocks now register only in Accommodation contexts (including relevant templates) with retry/timing and isActive gating for reliable editor loading.
  * Added internationalisation, descriptions and keywords for better discoverability.
  * Build assets declare wp‑i18n dependency.

* **Documentation**
  * Example content added to illustrate block usage.

* **Chores**
  * Internal global storage variable renamed for content model paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->