### PR TITLE
fix: Hide location field when no Google Maps API key is present

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,6 @@
 
 ## [[2.1.0]](https://github.com/lightspeedwp/tour-operator/releases/tag/2.1.0) - In Dev
 
-### Changed
-
-
 ### Added
 - A filter to allow the disabling of destinations when searching for related content. `lsx_to_' . $key . '_include_destinations`. - [BH-74](https://www.bugherd.com/projects/430995/tasks/74)
 - Integrate new icons block - PR [#547](https://github.com/lightspeedwp/tour-operator/pull/547), Issue [#548](https://github.com/lightspeedwp/tour-operator/issues/548)
@@ -57,6 +54,7 @@
 - Add "currentColor" to all icon colour styling [#575](https://github.com/lightspeedwp/tour-operator/pull/575)
 - Query Block Pagination not Inherting the correct query vars. [#608](https://github.com/lightspeedwp/tour-operator/pull/608)
 - Fixed – Excluded build/ directory from CodeRabbit reviews by updating .coderabbit.yaml. [#620](https://github.com/lightspeedwp/tour-operator/pull/620)
+- Hide "location" custom field and exclude relevant JS when Google Maps API key is missing. Only the map field is shown. ([#657](https://github.com/lightspeedwp/tour-operator/issues/657))
 
 ### Security
 - 

--- a/includes/metaboxes/config-accommodation.php
+++ b/includes/metaboxes/config-accommodation.php
@@ -61,17 +61,20 @@ if (! isset(tour_operator()->options['display']['maps_disable']) && empty(tour_o
 	if (isset(tour_operator()->options['googlemaps_key']) && ! empty(tour_operator()->options['googlemaps_key'])) {
 		$google_api_key = tour_operator()->options['googlemaps_key'];
 	}
-	$metabox['fields'][] = array(
-		'id'      => 'location',
-		'name'    => esc_html__('Address', 'tour-operator'),
-		'desc'    => esc_html__('The address of the accommodation for map display.', 'tour-operator'),
-		'type'    => 'pw_map',
-		'api_key' => $google_api_key,
-	);
+	if ( ! empty( $google_api_key ) ) {
+		$metabox['fields'][] = array(
+			'id'      => 'location',
+			'name'    => esc_html__('Address', 'tour-operator'),
+			'desc'    => esc_html__('The address of the accommodation for map display.', 'tour-operator'),
+			'type'    => 'pw_map',
+			'api_key' => $google_api_key,
+		);
+	}
+
 	$metabox['fields'][] = array(
 		'id'           => 'map_placeholder',
 		'name'         => esc_html__('Map Placeholder', 'tour-operator'),
-		'desc'         => esc_html__('A placeholder image for the map if no address or GPS data is available.', 'tour-operator'),
+		'desc'         => esc_html__('A placeholder image for the map, allowing lazy loading.', 'tour-operator'),
 		'type'         => 'file',
 		'repeatable'   => false,
 		'show_size'    => false,

--- a/includes/metaboxes/config-destination.php
+++ b/includes/metaboxes/config-destination.php
@@ -171,12 +171,14 @@ if (! isset(tour_operator()->options['display']['maps_disable']) && empty(tour_o
 	if (isset(tour_operator()->options['googlemaps_key']) && ! empty(tour_operator()->options['googlemaps_key'])) {
 		$google_api_key = tour_operator()->options['googlemaps_key'];
 	}
-	$metabox['fields'][] = array(
-		'id'      => 'location',
-		'name'    => esc_html__('Address', 'tour-operator'),
-		'type'    => 'pw_map',
-		'api_key' => $google_api_key,
-	);
+	if ( ! empty($google_api_key) ) {
+		$metabox['fields'][] = array(
+			'id'      => 'location',
+			'name'    => esc_html__('Address', 'tour-operator'),
+			'type'    => 'pw_map',
+			'api_key' => $google_api_key,
+		);
+	}
 	$metabox['fields'][] = array(
 		'id'         => 'map_placeholder',
 		'name'       => esc_html__('Map Placeholder', 'tour-operator'),


### PR DESCRIPTION
## Context
- Severity/Impact: Medium
- Affected versions/environments: All versions of tour-operator plugin

## Reproduction
1) Install/activate tour-operator plugin
2) Navigate to Accommodation or Destination editing screen
3) Notice the "Location" field is shown even when no Google Maps API key is configured
4) The field doesn't work correctly without an API key and may lead to confusion

## Root Cause
- The location field with the map was always displayed in the Accommodation and Destination metaboxes, regardless of whether a Google Maps API key was configured.
- This led to a non-functional map field when no API key was present.

## Fix Summary
- Added conditional logic in both `config-accommodation.php` and `config-destination.php` to only show the location field when a Google Maps API key is properly configured.
- Updated the description of the map placeholder field to clarify its purpose.
- This prevents displaying a non-functional map field to users who haven't configured a Maps API key.

## Verification
- [x] Confirmed that the location field is hidden when no API key is present
- [x] Confirmed that the location field appears correctly when an API key is configured
- [x] Updated changelog to document this change

## Risk & Rollback
- Risk level: Low
- Rollback plan: Simple revert would restore previous behavior

Fixes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Hide the location/map field when no valid Google Maps API key is configured.
  - Prevent loading of map-related scripts without a key, reducing errors and unnecessary requests.
- Documentation
  - Updated changelog to note conditional visibility of the location field and script exclusion without an API key.
  - Clarified map placeholder text to explain lazy-loading behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->