### PR TITLE
Hotfix/filter needed lsx travel information excerpt length

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@
 - Tagline block which pulls the text set in the Tagline field. - [#604](https://github.com/lightspeedwp/tour-operator/pull/604)
 - Added in a filter to allow the disabling of the facility block links - `lsx_to_accommodation_facilities_should_link` - [#608](https://github.com/lightspeedwp/tour-operator/pull/608)
 - Added in a filter to allow the ordering of the query blocks by post__in. - [#653](https://github.com/lightspeedwp/tour-operator/pull/653)
+- Added filter `lsx_travel_information_excerpt_length` to control character length for travel information excerpts [#663](https://github.com/lightspeedwp/tour-operator/pull/663)
+- Added filter `lsx_travel_information_modal_enable` to optionally disable travel information modal functionality [#663](https://github.com/lightspeedwp/tour-operator/pull/663)
 
 ### Enhancements
 - Updated block icons for various block variations: Custom SVGs were added to: dress, facilities, health, ends-in, departs-from, climate, transport. [#579](https://github.com/lightspeedwp/tour-operator/pull/579)

--- a/includes/classes/frontend/class-modals.php
+++ b/includes/classes/frontend/class-modals.php
@@ -295,6 +295,11 @@ class Modals {
 	 * Filter the travel information and return a shortened version.
 	 */
 	public function travel_information_excerpt( $html = '', $meta_key = false, $value = false, $before = '', $after = '' ) {
+
+		if ( false === apply_filters( 'lsx_travel_information_modal_enable', true ) ) {
+			return $html;
+		}
+
 		// Allow 3rd party to override the character limit.
 		$limit_chars = apply_filters( 'lsx_travel_information_excerpt_length', 150 );
 		$ti_keys     = [

--- a/includes/classes/frontend/class-modals.php
+++ b/includes/classes/frontend/class-modals.php
@@ -295,7 +295,8 @@ class Modals {
 	 * Filter the travel information and return a shortened version.
 	 */
 	public function travel_information_excerpt( $html = '', $meta_key = false, $value = false, $before = '', $after = '' ) {
-		$limit_chars = 150;
+		// Allow 3rd party to override the character limit.
+		$limit_chars = apply_filters( 'lsx_travel_information_excerpt_length', 150 );
 		$ti_keys     = [
 			'electricity',
 			'banking',


### PR DESCRIPTION
---
name: "Hotfix/Security PR"
about: "Urgent bug or security fix with fast rollback path"
title: "hotfix: Add filter to control travel information excerpt length"
---

## Context
- Severity/Impact: Medium
- Affected versions/environments: Tour Operator 2.1.0-dev

## Reproduction
1. Visit a destination page with travel information content
2. Observe that travel information excerpts are limited to 150 characters
3. Try to customize the excerpt length through theme code

## Fix Summary
- Added two filter hooks to allow developers to customize travel information handling:
  - `lsx_travel_information_excerpt_length` - Controls the character limit for travel information excerpts (default: 150)
  - `lsx_travel_information_modal_enable` - Allows disabling the travel information modal functionality (default: true)

## Verification
- [x] Verified on local development environment
- [x] Tested with custom filters to override default values
- [x] Confirmed modal functionality works with different excerpt lengths

## Risk & Rollback
- Risk level: Low
- Rollback plan: Revert the commit if issues arise

---
### Checklist (Global DoD / PR)
- [x] All AC met and demonstrated
- [ ] Tests added/updated (unit/E2E as appropriate)
- [x] A11y considerations addressed where relevant
- [x] Docs/readme/changelog updated (if user-facing)
- [ ] Security/perf impact reviewed where relevant
- [ ] Code/design reviews approved
- [ ] CI green; linked issues closed; release notes prepared (if shipping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable the Travel Information modal for a simpler viewing experience.
  * Introduced a configurable character limit for Travel Information excerpts (default 150), allowing finer control over summary length.

* **Documentation**
  * Updated the changelog to reflect the new configuration options for the Travel Information modal and excerpt length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->