### PR TITLE
Add filter to allow third parties to alter query arguments in Query_Loop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Added in a filter to allow the ordering of the query blocks by post__in. - [#653](https://github.com/lightspeedwp/tour-operator/pull/653)
 - Added filter `lsx_travel_information_excerpt_length` to control character length for travel information excerpts [#663](https://github.com/lightspeedwp/tour-operator/pull/663)
 - Added filter `lsx_travel_information_modal_enable` to optionally disable travel information modal functionality [#663](https://github.com/lightspeedwp/tour-operator/pull/663)
+- Added filter `lsx_to_query_loop_query_args_{$key}` to allow third parties to alter query arguments in Query_Loop class - [#675](https://github.com/lightspeedwp/tour-operator/pull/675)
 
 ### Enhancements
 - Updated block icons for various block variations: Custom SVGs were added to: dress, facilities, health, ends-in, departs-from, climate, transport. [#579](https://github.com/lightspeedwp/tour-operator/pull/579)

--- a/includes/classes/blocks/class-query-loop.php
+++ b/includes/classes/blocks/class-query-loop.php
@@ -396,6 +396,9 @@ class Query_Loop {
 			$query['order'] = 'ASC';
 		}
 
+		// Allow 3rd Parties to alter the query args
+		$query = apply_filters( 'lsx_to_query_loop_query_args_' . $key, $query, $block );
+
 		// Store the processed query for this queryId (if available) and also keep legacy property.
 		if ( null !== $query_id ) {
 			$this->saved_queries[ $query_id ] = $query;


### PR DESCRIPTION
## Description

This hotfix adds a new filter `lsx_to_query_loop_query_args_{$key}` to the Query_Loop class, allowing third-party developers to modify query arguments for specific query loop variations.

## Changes Made

- Added `apply_filters( 'lsx_to_query_loop_query_args_' . $key, $query, $block )` in the `query_args_filter` method
- This filter is applied after all internal query modifications but before storing the processed query
- The filter allows modification of query arguments based on the specific query key (e.g., regions, accommodation-related-tour, etc.)

## Benefits

- Provides extensibility for third-party plugins to customize query behavior
- Maintains backward compatibility
- Follows WordPress coding standards for filter naming conventions

## Testing

- [ ] Verify existing query loop functionality remains unchanged
- [ ] Test that third-party filters can successfully modify query arguments
- [ ] Ensure proper filter parameters are passed ($query and $block)

## Files Modified

- `includes/classes/blocks/class-query-loop.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an extensible filter point for dynamically customising query arguments within core block variations.
  * Query arguments can now be intercepted and modified at the processing stage across different block variations, whilst preserving full compatibility with existing query handling, post ordering functionality, and caching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->