### PR TITLE
Post Type single and archive slugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,10 +32,13 @@
 
 ### Enhancements
 
+#### Frontend
 - **Tour summary information** - Added price info and title in the tour summary section for better visibility
 - **Block gap consistency** - Adjusted block gap spacing for improved visual consistency across templates
 - **Travel information cards** - Increased padding for travel information cards to improve readability
 
+#### Backend
+- **Post Type Permalinks** - Extended the Taxonomy permalinks to handle Post Type Permalinks as well. This only covers the single items.
 
 ## [[2.1.1]](https://github.com/lightspeedwp/tour-operator/releases/tag/2.1.1) - 2026-01-05
 

--- a/changelog.md
+++ b/changelog.md
@@ -38,7 +38,7 @@
 - **Travel information cards** - Increased padding for travel information cards to improve readability
 
 #### Backend
-- **Post Type Permalinks** - Extended the Taxonomy permalinks to handle Post Type Permalinks as well. This only covers the single items.
+- **Post Type Permalinks** - Extended the Taxonomy permalinks to handle Post Type Permalinks for the single and archive slugs.
 
 ## [[2.1.1]](https://github.com/lightspeedwp/tour-operator/releases/tag/2.1.1) - 2026-01-05
 

--- a/includes/classes/admin/class-permalinks.php
+++ b/includes/classes/admin/class-permalinks.php
@@ -70,8 +70,7 @@ class Permalinks
 	 * @param array $input Raw input from the form.
 	 * @return array Sanitized input.
 	 */
-	public function sanitize_permalink_fields($input)
-	{
+	public function sanitize_permalink_fields( $input ) {
 		$sanitized = array();
 		$fields    = $this->get_post_type_fields( $this->defaults );
 
@@ -101,7 +100,7 @@ class Permalinks
 			],
 		];
 		?>
-		<h2><?php esc_html_e('Tour Operator', 'tour-operator'); ?></h2>
+		<h2><?php esc_html_e('Tour Operator - Taxonomies', 'tour-operator'); ?></h2>
 		<table class="form-table">
 			<p>Use the following fields to alter the base slug for the Tour Operator taxonomies like <code><?php echo esc_html(home_url()); ?>/travel-style/honeymoon/</code></p>
 			<?php
@@ -127,6 +126,7 @@ class Permalinks
 
 		$fields = $this->get_post_type_fields( [] );
 		?>
+		<h2><?php esc_html_e('Tour Operator - Post Types', 'tour-operator'); ?></h2>
 		<table class="form-table">
 			<p>Use the following fields to alter the base slug for the Tour Operator post types like <code><?php echo esc_html(home_url()); ?>/destination/south-africa/</code></p>
 			<?php
@@ -210,7 +210,8 @@ class Permalinks
 				$types
 			);
 			foreach ( $types as $types ) {
-				$fields[ $types['slug'] ] = [ 'label' => $types['label'] ];
+				$fields[ $types['slug'] ] = [ 'label' => __( 'Single', 'tour-operator' ) . ' ' . $types['label'] ];
+				$fields[ 'archive_' . $types['slug'] ] = [ 'label' => __( 'Archive', 'tour-operator' ) . ' ' . $types['label'] ];
 			}
 		}
 
@@ -244,6 +245,11 @@ class Permalinks
 		if ( isset( $slug_options[ 'lsx_to_' . $slug ] ) && '' !== $slug_options[ 'lsx_to_' . $slug ] ) {
 			$post_type['rewrite']['slug'] = $slug_options[ 'lsx_to_' . $slug ];
 		}
+
+		if ( isset( $slug_options[ 'lsx_to_archive_' . $slug ] ) && '' !== $slug_options[ 'lsx_to_archive_' . $slug ] ) {
+			$post_type['has_archive'] = $slug_options[ 'lsx_to_archive_' . $slug ];
+		}
+
 		return $post_type;
 	}
 }

--- a/includes/classes/admin/class-permalinks.php
+++ b/includes/classes/admin/class-permalinks.php
@@ -26,9 +26,9 @@ class Permalinks
 	 * @var array
 	 */
 	public $defaults = array(
-		'lsx_to_travel-style'        => '',
-		'lsx_to_accommodation-type'  => '',
-		'lsx_to_accommodation-brand' => '',
+		'travel-style'        => '',
+		'accommodation-type'  => '',
+		'accommodation-brand' => '',
 	);
 
 	/**
@@ -38,7 +38,8 @@ class Permalinks
 		add_action('admin_init', [$this, 'register_permalink_settings']);
 		add_action('admin_init', [$this, 'save_custom_permalink_fields'], 20);
 		add_filter('lsx_to_register_taxonomy_args', [$this, 'apply_taxonomy_slugs'], 10, 2);
-		add_filter('lsx_to_content_model_post_types', [$this, 'alter_post_type_slugs']);
+		add_filter('lsx_to_content_model_post_type', [$this, 'alter_post_type_slugs']);
+		add_filter('content_model_post_type_args', [$this, 'alter_post_type_args'], 10, 2);
 	}
 
 	/**
@@ -72,9 +73,10 @@ class Permalinks
 	public function sanitize_permalink_fields($input)
 	{
 		$sanitized = array();
+		$fields    = $this->get_post_type_fields( $this->defaults );
 
-		foreach ($this->defaults as $key => $default) {
-			$sanitized[$key] = isset($input[$key]) ? sanitize_text_field($input[$key]) : '';
+		foreach ( $fields as $key => $default ) {
+			$sanitized[ 'lsx_to_' . $key ] = isset( $input[ 'lsx_to_' . $key ] ) ? sanitize_text_field( $input[ 'lsx_to_' . $key ] ) : '';
 		}
 
 		return $sanitized;
@@ -83,8 +85,7 @@ class Permalinks
 	/**
 	 * Register new fields to the permalink settings page.
 	 */
-	public function permalink_fields()
-	{
+	public function permalink_fields() {
 		// Get existing options or defaults.
 		$options = get_option('lsx_to_slugs', $this->defaults);
 
@@ -99,19 +100,47 @@ class Permalinks
 				'label' => esc_html__('Brand', 'tour-operator'),
 			],
 		];
-		$fields = $this->get_post_type_fields( $fields );
-
 		?>
 		<h2><?php esc_html_e('Tour Operator', 'tour-operator'); ?></h2>
 		<table class="form-table">
 			<p>Use the following fields to alter the base slug for the Tour Operator taxonomies like <code><?php echo esc_html(home_url()); ?>/travel-style/honeymoon/</code></p>
 			<?php
 			foreach ($fields as $key => $field) {
+			if ( isset( $options['lsx_to_' . $key] ) ) {
+				$value = $options['lsx_to_' . $key];
+			} else {
+				$value = '';
+			}
 			?>
 				<tr>
 					<th scope="row"><label for="<?php echo esc_attr($key); ?>"><?php echo esc_attr($field['label']); ?></label></th>
 					<td>
-						<input type="text" id="<?php echo esc_attr($key); ?>" name="lsx_to_slugs[lsx_to_<?php echo esc_attr($key); ?>]" value="<?php echo esc_attr($options['lsx_to_' . $key]); ?>" class="regular-text" />
+						<input type="text" id="<?php echo esc_attr($key); ?>" name="lsx_to_slugs[lsx_to_<?php echo esc_attr($key); ?>]" value="<?php echo esc_attr( $value ); ?>" class="regular-text" />
+					</td>
+				</tr>
+			<?php
+			}
+			?>
+		</table>
+		<?php
+
+
+		$fields = $this->get_post_type_fields( [] );
+		?>
+		<table class="form-table">
+			<p>Use the following fields to alter the base slug for the Tour Operator post types like <code><?php echo esc_html(home_url()); ?>/destination/south-africa/</code></p>
+			<?php
+			foreach ($fields as $key => $field) {
+			if ( isset( $options['lsx_to_' . $key] ) ) {
+				$value = $options['lsx_to_' . $key];
+			} else {
+				$value = '';
+			}
+			?>
+				<tr>
+					<th scope="row"><label for="<?php echo esc_attr($key); ?>"><?php echo esc_attr($field['label']); ?></label></th>
+					<td>
+						<input type="text" id="<?php echo esc_attr($key); ?>" name="lsx_to_slugs[lsx_to_<?php echo esc_attr($key); ?>]" value="<?php echo esc_attr( $value ); ?>" class="regular-text" />
 					</td>
 				</tr>
 			<?php
@@ -180,8 +209,8 @@ class Permalinks
 				fn( $file ) => json_decode( file_get_contents( $file ), true ),
 				$types
 			);
-			foreach ( $types as $type ) {
-				$fields[ 'lsx_to_' . $type['slug'] ] = $type['label'];
+			foreach ( $types as $types ) {
+				$fields[ $types['slug'] ] = [ 'label' => $types['label'] ];
 			}
 		}
 
@@ -196,8 +225,24 @@ class Permalinks
 	 */
 	public function alter_post_type_slugs( $post_type ) {
 		$slug_options = get_option( 'lsx_to_slugs', $this->defaults );
-		if ( isset( $slug_options[ 'lsx_to_' . $post_type ] ) && '' !== $slug_options[ 'lsx_to_' . $post_type ] ) {
-			$post_type[ 'slug' ] = $slug_options[ 'lsx_to_' . $post_type ];
+
+		if ( isset( $slug_options[ 'lsx_to_' . $post_type['slug'] ] ) && '' !== $slug_options[ 'lsx_to_' . $post_type['slug'] ] ) {
+			$post_type['slug'] = $slug_options[ 'lsx_to_' . $post_type['slug'] ];
+		}
+		return $post_type;
+	}
+
+	/**
+	 * Alters the post type slugs based on the saved options.
+	 *
+	 * @param array $post_type The post type arguments.
+	 * @return array The modified post type arguments.
+	 */
+	public function alter_post_type_args( $post_type, $slug ) {
+		$slug_options = get_option( 'lsx_to_slugs', $this->defaults );
+
+		if ( isset( $slug_options[ 'lsx_to_' . $slug ] ) && '' !== $slug_options[ 'lsx_to_' . $slug ] ) {
+			$post_type['rewrite']['slug'] = $slug_options[ 'lsx_to_' . $slug ];
 		}
 		return $post_type;
 	}

--- a/includes/classes/admin/class-permalinks.php
+++ b/includes/classes/admin/class-permalinks.php
@@ -34,18 +34,17 @@ class Permalinks
 	/**
 	 * Constructor.
 	 */
-	public function __construct()
-	{
+	public function __construct() {
 		add_action('admin_init', [$this, 'register_permalink_settings']);
 		add_action('admin_init', [$this, 'save_custom_permalink_fields'], 20);
 		add_filter('lsx_to_register_taxonomy_args', [$this, 'apply_taxonomy_slugs'], 10, 2);
+		add_filter('lsx_to_content_model_post_types', [$this, 'alter_post_type_slugs']);
 	}
 
 	/**
 	 * Register the setting to save custom fields.
 	 */
-	public function register_permalink_settings()
-	{
+	public function register_permalink_settings() {
 		register_setting(
 			'permalink',
 			'lsx_to_slugs',
@@ -100,8 +99,9 @@ class Permalinks
 				'label' => esc_html__('Brand', 'tour-operator'),
 			],
 		];
+		$fields = $this->get_post_type_fields( $fields );
 
-?>
+		?>
 		<h2><?php esc_html_e('Tour Operator', 'tour-operator'); ?></h2>
 		<table class="form-table">
 			<p>Use the following fields to alter the base slug for the Tour Operator taxonomies like <code><?php echo esc_html(home_url()); ?>/travel-style/honeymoon/</code></p>
@@ -118,7 +118,7 @@ class Permalinks
 			}
 			?>
 		</table>
-<?php
+		<?php
 	}
 
 	/**
@@ -126,8 +126,7 @@ class Permalinks
 	 *
 	 * @return void
 	 */
-	public function save_custom_permalink_fields()
-	{
+	public function save_custom_permalink_fields() {
 		if (
 			isset($_POST['lsx_to_slugs']) &&
 			is_array($_POST['lsx_to_slugs']) &&
@@ -148,8 +147,7 @@ class Permalinks
 	 * @param array $object_types
 	 * @return array
 	 */
-	public function apply_taxonomy_slugs($args, $taxonomy)
-	{
+	public function apply_taxonomy_slugs( $args, $taxonomy ) {
 		$slug_options = get_option('lsx_to_slugs', $this->defaults);
 
 		foreach ($slug_options as $key => $option) {
@@ -162,5 +160,45 @@ class Permalinks
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Get the TO post types from the JSON files.
+	 *
+	 * @return array An array of post types, keyed by their slug.
+	 */
+	public function get_post_type_fields( $fields ) {
+
+		global $CONTENT_MODEL_JSON_PATH;
+		if ( ! isset( $CONTENT_MODEL_JSON_PATH ) ) {
+			return $fields;
+		}
+		
+		foreach ( $CONTENT_MODEL_JSON_PATH as $json_path ) {
+			$types = glob( $json_path . '/post-types/*.json' );
+			$types = array_map(
+				fn( $file ) => json_decode( file_get_contents( $file ), true ),
+				$types
+			);
+			foreach ( $types as $type ) {
+				$fields[ 'lsx_to_' . $type['slug'] ] = $type['label'];
+			}
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Alters the post type slugs based on the saved options.
+	 *
+	 * @param array $post_type The post type arguments.
+	 * @return array The modified post type arguments.
+	 */
+	public function alter_post_type_slugs( $post_type ) {
+		$slug_options = get_option( 'lsx_to_slugs', $this->defaults );
+		if ( isset( $slug_options[ 'lsx_to_' . $post_type ] ) && '' !== $slug_options[ 'lsx_to_' . $post_type ] ) {
+			$post_type[ 'slug' ] = $slug_options[ 'lsx_to_' . $post_type ];
+		}
+		return $post_type;
 	}
 }

--- a/includes/classes/legacy/class-accommodation.php
+++ b/includes/classes/legacy/class-accommodation.php
@@ -53,6 +53,14 @@ class Accommodation {
 	public $unit_types = false;
 
 	/**
+	 * Holds the Tour post type options.
+	 *
+	 * @since 1.0.0
+	 * @var array|bool
+	 */
+	public $options = false;
+
+	/**
 	 * Initialize the plugin by setting localization, filters, and
 	 * administration functions.
 	 *

--- a/includes/classes/legacy/class-tour-operator.php
+++ b/includes/classes/legacy/class-tour-operator.php
@@ -39,6 +39,30 @@ class Tour_Operator {
 	public $framework = false;
 
 	/**
+	 * Holds the admin class instance.
+	 *
+	 * @since 1.0.0
+	 * @var object
+	 */
+	public $admin = false;
+
+	/**
+	 * Holds the frontend class instance.
+	 *
+	 * @since 1.0.0
+	 * @var object
+	 */
+	public $frontend = false;
+
+	/**
+	 * Holds the placeholders class instance.
+	 *
+	 * @since 1.0.0
+	 * @var object
+	 */
+	public $placeholders = false;
+
+	/**
 	 * Holds the array of post_types
 	 *
 	 * @since 1.0.0
@@ -124,6 +148,14 @@ class Tour_Operator {
 	 * @var array
 	 */
 	public $map_post_type = array();
+
+	/**
+	 * Holds an array of post types used for map markers.
+	 *
+	 * @since 1.1.5
+	 * @var array
+	 */
+	public $map_post_types = array();
 
 	/**
 	 * Holds an array of the marker URLs
@@ -378,7 +410,7 @@ class Tour_Operator {
 	public function require_post_type_classes() {
 		foreach ( $this->post_types as $post_type => $label ) {
 			if ( class_exists( "lsx\\legacy\\{$post_type}" ) ) {
-				$this->$post_type = call_user_func_array( array( "lsx\\legacy\\{$post_type}", 'get_instance' ), array() );
+				call_user_func_array( array( "lsx\\legacy\\{$post_type}", 'get_instance' ), array() );
 			}
 		}
 

--- a/includes/classes/legacy/class-tour.php
+++ b/includes/classes/legacy/class-tour.php
@@ -46,6 +46,22 @@ class Tour
 	public $search_fields = false;
 
 	/**
+	 * Holds the Tour post type options.
+	 *
+	 * @since 1.0.0
+	 * @var array|bool
+	 */
+	public $options = false;
+
+	/**
+	 * Flags whether the WETU importer is active.
+	 *
+	 * @since 1.0.0
+	 * @var bool
+	 */
+	public $is_wetu_active = false;
+
+	/**
 	 * Initialize the plugin by setting localization, filters, and
 	 * administration functions.
 	 *


### PR DESCRIPTION
## Summary

Add explicit public property declarations to legacy `Tour_Operator` and `Tour` classes to eliminate dynamic property usage and improve code clarity.

## Changes

- **class-tour-operator.php**: Added declarations for `$admin`, `$frontend`, `$placeholders`, and `$map_post_types`
- **class-tour.php**: Added declarations for `$options` and `$is_wetu_active`

These changes ensure all class properties are properly typed and documented, reducing reliance on PHP's dynamic property access and improving IDE support and static analysis compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tour summaries now display price information and title details
  * Post Type Permalinks support extended for flexible permalink configuration on both single and archive pages

* **Improvements**
  * Block gap spacing adjusted for improved visual consistency
  * Travel information cards now feature increased padding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->