### PR TITLE
Fix: Enhance breadcrumb links priority and destination hierarchy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,9 @@
 #### Backend
 - **Post Type Permalinks** - Extended the Taxonomy permalinks to handle Post Type Permalinks for the single and archive slugs.
 
+#### Code Quality
+- **Breadcrumb text and URL refactoring** - Extracted repeated breadcrumb text strings and post type archive URLs to class properties (`$home_text`, `$home_url`, `$destinations_text`, `$destinations_url`, `$tours_text`, `$tours_url`, `$accommodation_text`, `$accommodation_url`) initialized in the constructor. Improves code maintainability by declaring values once and reduces repeated function calls for better performance.
+
 ## [[2.1.1]](https://github.com/lightspeedwp/tour-operator/releases/tag/2.1.1) - 2026-01-05
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
   - Expanded taxonomy breadcrumb support from continent-only to include accommodation-brand, travel-style, and accommodation-type taxonomies, each linking to their respective post type archives
   - Renamed `continent_breadcrumb_links()` to `taxonomy_breadcrumb_links()` for better semantic clarity and added switch logic for multiple taxonomy types
   - Created new `archive_breadcrumbs_links()` method to handle post type archive breadcrumb generation
+  - Fixed timing issue by moving `get_post_type_archive_link()` calls from constructor to `wpseo_breadcrumb_links` filter callback via new `init_breadcrumb_properties()` method, ensuring post types are registered and permalink structure is ready before generating archive URLs
 
 #### Layout & Styling
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 #### Editor & Navigation
 
 - **Navigation Link variation labels for CPTs and taxonomies** - Added missing `item_link` and `item_link_description` labels plus explicit `show_in_nav_menus` support for Tour Operator content models and related taxonomies so they appear correctly in Navigation Link variations and link pickers - Issue [#922](https://github.com/lightspeedwp/tour-operator/issues/922), Issue [#923](https://github.com/lightspeedwp/tour-operator/issues/923)
+- **Breadcrumb links priority and structure** - Increased Yoast SEO breadcrumb filter priority from 20 to 200 to ensure Tour Operator breadcrumb customisations take precedence. Enhanced destination breadcrumb structure to properly build hierarchical paths including Home → Destinations → Continent → Parent Destination → Current Destination for improved navigation clarity
 
 #### Layout & Styling
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,13 @@
 #### Editor & Navigation
 
 - **Navigation Link variation labels for CPTs and taxonomies** - Added missing `item_link` and `item_link_description` labels plus explicit `show_in_nav_menus` support for Tour Operator content models and related taxonomies so they appear correctly in Navigation Link variations and link pickers - Issue [#922](https://github.com/lightspeedwp/tour-operator/issues/922), Issue [#923](https://github.com/lightspeedwp/tour-operator/issues/923)
-- **Breadcrumb links priority and structure** - Increased Yoast SEO breadcrumb filter priority from 20 to 200 to ensure Tour Operator breadcrumb customisations take precedence. Enhanced destination breadcrumb structure to properly build hierarchical paths including Home → Destinations → Continent → Parent Destination → Current Destination for improved navigation clarity
+- **Breadcrumb links priority and hierarchical structure** - Comprehensive breadcrumb improvements for Tour Operator content:
+  - Increased Yoast SEO breadcrumb filter priority from 20 to 200 to ensure Tour Operator breadcrumb customisations take precedence over other plugins
+  - Enhanced destination single page breadcrumbs to properly build hierarchical paths: Home → Destinations → Continent → Parent Destination → Current Destination
+  - Added post type archive breadcrumbs for destination, accommodation, and tour archives with proper Home → Archive structure
+  - Expanded taxonomy breadcrumb support from continent-only to include accommodation-brand, travel-style, and accommodation-type taxonomies, each linking to their respective post type archives
+  - Renamed `continent_breadcrumb_links()` to `taxonomy_breadcrumb_links()` for better semantic clarity and added switch logic for multiple taxonomy types
+  - Created new `archive_breadcrumbs_links()` method to handle post type archive breadcrumb generation
 
 #### Layout & Styling
 

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -138,22 +138,58 @@ class Frontend extends Tour_Operator
 			$crumbs = $this->continent_breadcrumb_links($crumbs);
 		}
 
-		if ( is_post_type_archive('destination') ) {
-			$crumbs = $this->continent_breadcrumb_links($crumbs);
+		// Post type archives
+		if ( is_post_type_archive( [ 'destination', 'accommodation', 'tour' ] ) ) {
+			$crumbs = $this->archive_breadcrumbs_links( $crumbs, get_post_type());
 		}
+
+		// Single Items
 		if (is_singular('destination')) {
 			$crumbs = $this->destination_breadcrumb_links($crumbs);
 		}
-
 		if (is_singular('accommodation')) {
 			$crumbs = $this->accommodation_breadcrumb_links($crumbs);
 		}
-
 		if (is_singular('tour')) {
 			$crumbs = $this->tour_breadcrumb_links($crumbs);
 		}
 
 		return $crumbs;
+	}
+
+	public function archive_breadcrumbs_links( $crumbs, $post_type ) {
+		$post_type_object = get_post_type_object( $post_type );
+		if ( ! is_post_type_archive( $post_type ) || ! $post_type_object ) {
+			return $crumbs;
+		}
+
+		switch ( $post_type ) {
+			case 'destination':
+				$text = esc_attr__('Destinations', 'tour-operator');
+				break;
+			case 'tour':
+				$text = esc_attr__('Tours', 'tour-operator');
+				break;
+			case 'accommodation':
+				$text = esc_attr__('Accommodation', 'tour-operator');
+				break;
+			default:
+				$text = esc_attr( $post_type_object->labels->name );
+				break;
+		}
+
+		$new_crumbs = array(
+			array(
+				'text' => esc_attr__('Home', 'tour-operator'),
+				'url'  => home_url(),
+			),
+			array(
+				'text' => $text,
+				'url'  => get_post_type_archive_link( $post_type ),
+			),
+		);
+
+		return $new_crumbs;
 	}
 
 	/**

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -52,7 +52,7 @@ class Frontend extends Tour_Operator
 		// Readmore
 		remove_filter('term_description', 'wpautop');
 
-		add_filter('wpseo_breadcrumb_links', array($this, 'wpseo_breadcrumb_links'), 20);
+		add_filter('wpseo_breadcrumb_links', array($this, 'wpseo_breadcrumb_links'), 200);
 	}
 
 	/**
@@ -133,6 +133,7 @@ class Frontend extends Tour_Operator
 	 */
 	public function wpseo_breadcrumb_links($crumbs)
 	{
+
 		if (is_tax('continent')) {
 			$crumbs = $this->continent_breadcrumb_links($crumbs);
 		}
@@ -177,6 +178,18 @@ class Frontend extends Tour_Operator
 	 */
 	public function destination_breadcrumb_links($crumbs)
 	{
+
+		$new_crumbs = array(
+			array(
+				'text' => esc_attr__('Home', 'tour-operator'),
+				'url'  => home_url(),
+			),
+			array(
+				'text' => esc_attr__('Destinations', 'tour-operator'),
+				'url'  => get_post_type_archive_link('destination'),
+			),
+		);
+
 		global $post;
 		$continents = wp_get_post_terms($post->ID, 'continent');
 		if (empty($continents) || ! is_array($continents)) {
@@ -194,11 +207,27 @@ class Frontend extends Tour_Operator
 					'url'  => get_term_link($continent),
 				);
 
-				array_splice($crumbs, 2, 0, array($continent_breadcrumb));
+				array_splice($new_crumbs, 2, 0, array($continent_breadcrumb));
 				break;
 			}
 		}
-		return $crumbs;
+
+		if ( null !== has_post_parent() ) {
+			$parent = get_post_parent();
+			$parent_breadcrumb = array(
+				'text' => $parent->post_title,
+				'url'  => get_permalink( $parent->ID ),
+			);
+
+			array_splice($new_crumbs, 3, 0, array($parent_breadcrumb));
+		}
+
+		$new_crumbs[] = array(
+			'text' => get_the_title(),
+			'url'  => get_permalink(),
+		);
+
+		return $new_crumbs;
 	}
 
 	/**
@@ -285,7 +314,8 @@ class Frontend extends Tour_Operator
 			);
 		} else {
 			$counter = 0;
-			$terms   = wp_get_object_terms(get_the_ID(), 'travel-style');
+			$terms   = wp_get_object_terms( get_the_ID(), 'travel-style');
+
 			if (! is_wp_error($terms) && ! empty($terms)) {
 				foreach ($terms as $term) {
 					if (0 < $counter) {

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -134,8 +134,8 @@ class Frontend extends Tour_Operator
 	public function wpseo_breadcrumb_links($crumbs)
 	{
 
-		if (is_tax('continent')) {
-			$crumbs = $this->continent_breadcrumb_links($crumbs);
+		if ( is_tax( [ 'continent', 'accommodation-brand', 'travel-style', 'accommodation-type' ] ) ) {
+			$crumbs = $this->taxonomy_breadcrumb_links($crumbs);
 		}
 
 		// Post type archives
@@ -198,14 +198,40 @@ class Frontend extends Tour_Operator
 	 * @param array $crumbs
 	 * @return array
 	 */
-	public function continent_breadcrumb_links($crumbs)
+	public function taxonomy_breadcrumb_links($crumbs)
 	{
-		$destination_breadcrumb = array(
-			'text' => esc_html__('Destinations', 'tour-operator'),
-			'url'  => get_post_type_archive_link('destination'),
-		);
-
-		array_splice($crumbs, 1, 0, array($destination_breadcrumb));
+		$taxonomy   = get_queried_object()->taxonomy;
+		$new_crumbs	= array();
+		switch ( $taxonomy ) {
+			case 'continent':
+				$new_crumbs = array(
+					'text' => esc_attr__('Destinations', 'tour-operator'),
+					'url'  => get_post_type_archive_link('destination'),
+				);
+				break;
+			case 'accommodation-brand':
+				$new_crumbs = array(
+					'text' => esc_attr__('Accommodation', 'tour-operator'),
+					'url'  => get_post_type_archive_link('accommodation'),
+				);
+				break;
+			case 'travel-style':
+				$new_crumbs = array(
+					'text' => esc_attr__('Tours', 'tour-operator'),
+					'url'  => get_post_type_archive_link('tour'),
+				);
+				break;
+			case 'accommodation-type':
+				$new_crumbs = array(
+					'text' => esc_attr__('Accommodation', 'tour-operator'),
+					'url'  => get_post_type_archive_link('accommodation'),
+				);
+				break;
+		}
+		if ( ! empty( $new_crumbs ) ) {
+			array_splice($crumbs, 1, 0, array( $new_crumbs ));
+		}
+		
 		return $crumbs;
 	}
 

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -43,6 +43,13 @@ class Frontend extends Tour_Operator
 	public $accommodation_url;
 
 	/**
+	 * Track if breadcrumb properties have been initialized
+	 *
+	 * @var bool
+	 */
+	private $breadcrumb_props_initialized = false;
+
+	/**
 	 * Initialize the plugin by setting localization, filters, and
 	 * administration functions.
 	 *
@@ -53,16 +60,6 @@ class Frontend extends Tour_Operator
 	{
 		$this->options = get_option('lsx_to_settings', false);
 		$this->set_vars();
-
-		// Set up breadcrumb text and URLs
-		$this->home_text           = esc_attr__('Home', 'tour-operator');
-		$this->home_url            = home_url();
-		$this->destinations_text   = esc_attr__('Destinations', 'tour-operator');
-		$this->destinations_url    = get_post_type_archive_link('destination');
-		$this->tours_text          = esc_attr__('Tours', 'tour-operator');
-		$this->tours_url           = get_post_type_archive_link('tour');
-		$this->accommodation_text  = esc_attr__('Accommodation', 'tour-operator');
-		$this->accommodation_url   = get_post_type_archive_link('accommodation');
 
 		add_action('wp_enqueue_scripts', array($this, 'enqueue_stylescripts'), 1);
 		add_filter('body_class', array($this, 'body_class'), 15, 1);
@@ -153,10 +150,34 @@ class Frontend extends Tour_Operator
 	}
 
 	/**
+	 * Initialize breadcrumb properties.
+	 *
+	 * @since 2.1.2
+	 */
+	private function init_breadcrumb_properties() {
+		if ( $this->breadcrumb_props_initialized ) {
+			return;
+		}
+
+		$this->home_text           = esc_attr__('Home', 'tour-operator');
+		$this->home_url            = home_url();
+		$this->destinations_text   = esc_attr__('Destinations', 'tour-operator');
+		$this->destinations_url    = get_post_type_archive_link('destination');
+		$this->tours_text          = esc_attr__('Tours', 'tour-operator');
+		$this->tours_url           = get_post_type_archive_link('tour');
+		$this->accommodation_text  = esc_attr__('Accommodation', 'tour-operator');
+		$this->accommodation_url   = get_post_type_archive_link('accommodation');
+
+		$this->breadcrumb_props_initialized = true;
+	}
+
+	/**
 	 * Add continent item to the breadcrumb.
 	 */
 	public function wpseo_breadcrumb_links($crumbs)
 	{
+		// Initialize breadcrumb properties when needed
+		$this->init_breadcrumb_properties();
 
 		if ( is_tax( [ 'continent', 'accommodation-brand', 'travel-style', 'accommodation-type' ] ) ) {
 			$crumbs = $this->taxonomy_breadcrumb_links($crumbs);

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -319,7 +319,7 @@ class Frontend extends Tour_Operator
 			}
 		}
 
-		if ( null !== has_post_parent() ) {
+		if ( has_post_parent() ) {
 			$parent = get_post_parent();
 			$parent_breadcrumb = array(
 				'text' => $parent->post_title,

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -33,21 +33,14 @@ class Frontend extends Tour_Operator
 	 *
 	 * @var string
 	 */
-	public $home_text;
-	public $home_url;
-	public $destinations_text;
-	public $destinations_url;
-	public $tours_text;
-	public $tours_url;
-	public $accommodation_text;
-	public $accommodation_url;
-
-	/**
-	 * Track if breadcrumb properties have been initialized
-	 *
-	 * @var bool
-	 */
-	private $breadcrumb_props_initialized = false;
+	public string $home_text;
+	public string $home_url;
+	public string $destinations_text;
+	public string $destinations_url;
+	public string $tours_text;
+	public string $tours_url;
+	public string $accommodation_text;
+	public string $accommodation_url;
 
 	/**
 	 * Initialize the plugin by setting localization, filters, and

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -138,6 +138,9 @@ class Frontend extends Tour_Operator
 			$crumbs = $this->continent_breadcrumb_links($crumbs);
 		}
 
+		if ( is_post_type_archive('destination') ) {
+			$crumbs = $this->continent_breadcrumb_links($crumbs);
+		}
 		if (is_singular('destination')) {
 			$crumbs = $this->destination_breadcrumb_links($crumbs);
 		}

--- a/includes/classes/legacy/class-frontend.php
+++ b/includes/classes/legacy/class-frontend.php
@@ -29,6 +29,20 @@ class Frontend extends Tour_Operator
 	public $maps = array();
 
 	/**
+	 * Breadcrumb text and URL properties
+	 *
+	 * @var string
+	 */
+	public $home_text;
+	public $home_url;
+	public $destinations_text;
+	public $destinations_url;
+	public $tours_text;
+	public $tours_url;
+	public $accommodation_text;
+	public $accommodation_url;
+
+	/**
 	 * Initialize the plugin by setting localization, filters, and
 	 * administration functions.
 	 *
@@ -39,6 +53,16 @@ class Frontend extends Tour_Operator
 	{
 		$this->options = get_option('lsx_to_settings', false);
 		$this->set_vars();
+
+		// Set up breadcrumb text and URLs
+		$this->home_text           = esc_attr__('Home', 'tour-operator');
+		$this->home_url            = home_url();
+		$this->destinations_text   = esc_attr__('Destinations', 'tour-operator');
+		$this->destinations_url    = get_post_type_archive_link('destination');
+		$this->tours_text          = esc_attr__('Tours', 'tour-operator');
+		$this->tours_url           = get_post_type_archive_link('tour');
+		$this->accommodation_text  = esc_attr__('Accommodation', 'tour-operator');
+		$this->accommodation_url   = get_post_type_archive_link('accommodation');
 
 		add_action('wp_enqueue_scripts', array($this, 'enqueue_stylescripts'), 1);
 		add_filter('body_class', array($this, 'body_class'), 15, 1);
@@ -165,27 +189,31 @@ class Frontend extends Tour_Operator
 
 		switch ( $post_type ) {
 			case 'destination':
-				$text = esc_attr__('Destinations', 'tour-operator');
+				$text = $this->destinations_text;
+				$url  = $this->destinations_url;
 				break;
 			case 'tour':
-				$text = esc_attr__('Tours', 'tour-operator');
+				$text = $this->tours_text;
+				$url  = $this->tours_url;
 				break;
 			case 'accommodation':
-				$text = esc_attr__('Accommodation', 'tour-operator');
+				$text = $this->accommodation_text;
+				$url  = $this->accommodation_url;
 				break;
 			default:
 				$text = esc_attr( $post_type_object->labels->name );
+				$url  = get_post_type_archive_link( $post_type );
 				break;
 		}
 
 		$new_crumbs = array(
 			array(
-				'text' => esc_attr__('Home', 'tour-operator'),
-				'url'  => home_url(),
+				'text' => $this->home_text,
+				'url'  => $this->home_url,
 			),
 			array(
 				'text' => $text,
-				'url'  => get_post_type_archive_link( $post_type ),
+				'url'  => $url,
 			),
 		);
 
@@ -205,26 +233,26 @@ class Frontend extends Tour_Operator
 		switch ( $taxonomy ) {
 			case 'continent':
 				$new_crumbs = array(
-					'text' => esc_attr__('Destinations', 'tour-operator'),
-					'url'  => get_post_type_archive_link('destination'),
+					'text' => $this->destinations_text,
+					'url'  => $this->destinations_url,
 				);
 				break;
 			case 'accommodation-brand':
 				$new_crumbs = array(
-					'text' => esc_attr__('Accommodation', 'tour-operator'),
-					'url'  => get_post_type_archive_link('accommodation'),
+					'text' => $this->accommodation_text,
+					'url'  => $this->accommodation_url,
 				);
 				break;
 			case 'travel-style':
 				$new_crumbs = array(
-					'text' => esc_attr__('Tours', 'tour-operator'),
-					'url'  => get_post_type_archive_link('tour'),
+					'text' => $this->tours_text,
+					'url'  => $this->tours_url,
 				);
 				break;
 			case 'accommodation-type':
 				$new_crumbs = array(
-					'text' => esc_attr__('Accommodation', 'tour-operator'),
-					'url'  => get_post_type_archive_link('accommodation'),
+					'text' => $this->accommodation_text,
+					'url'  => $this->accommodation_url,
 				);
 				break;
 		}
@@ -246,12 +274,12 @@ class Frontend extends Tour_Operator
 
 		$new_crumbs = array(
 			array(
-				'text' => esc_attr__('Home', 'tour-operator'),
-				'url'  => home_url(),
+				'text' => $this->home_text,
+				'url'  => $this->home_url,
 			),
 			array(
-				'text' => esc_attr__('Destinations', 'tour-operator'),
-				'url'  => get_post_type_archive_link('destination'),
+				'text' => $this->destinations_text,
+				'url'  => $this->destinations_url,
 			),
 		);
 
@@ -305,12 +333,12 @@ class Frontend extends Tour_Operator
 	{
 		$new_crumbs = array(
 			array(
-				'text' => esc_attr__('Home', 'tour-operator'),
-				'url'  => home_url(),
+				'text' => $this->home_text,
+				'url'  => $this->home_url,
 			),
 			array(
-				'text' => esc_attr__('Accommodation', 'tour-operator'),
-				'url'  => get_post_type_archive_link('accommodation'),
+				'text' => $this->accommodation_text,
+				'url'  => $this->accommodation_url,
 			),
 		);
 
@@ -359,12 +387,12 @@ class Frontend extends Tour_Operator
 	{
 		$new_crumbs = array(
 			array(
-				'text' => esc_attr__('Home', 'tour-operator'),
-				'url'  => home_url(),
+				'text' => $this->home_text,
+				'url'  => $this->home_url,
 			),
 			array(
-				'text' => esc_attr__('Tours', 'tour-operator'),
-				'url'  => get_post_type_archive_link('tour'),
+				'text' => $this->tours_text,
+				'url'  => $this->tours_url,
 			),
 		);
 


### PR DESCRIPTION
## Summary

This PR enhances the Yoast SEO breadcrumb integration for Tour Operator content, improving navigation clarity and ensuring proper breadcrumb hierarchy for destinations.

## Changes

### Breadcrumb Filter Priority
- Increased Yoast SEO `wpseo_breadcrumb_links` filter priority from **20 to 200**
- Ensures Tour Operator breadcrumb customisations take precedence over other plugins/themes

### Destination Breadcrumb Structure  
Enhanced `destination_breadcrumb_links()` to build a complete hierarchical breadcrumb path:
- **Home** → **Destinations** → **Continent** → **Parent Destination** → **Current Destination**
- Properly handles parent-child destination relationships
- Creates new breadcrumb array from scratch for better control
- Adds continent taxonomy integration
- Includes parent destination when applicable

### Code Quality
- Minor formatting improvements in `tour_breadcrumb_links()` method

## Testing
- ✅ Breadcrumbs display correctly for top-level destinations
- ✅ Breadcrumbs show parent destination for child destinations  
- ✅ Continent taxonomy appears in breadcrumb trail when assigned
- ✅ Filter priority prevents conflicts with other plugins

## Files Changed
- `includes/classes/legacy/class-frontend.php`

## Changelog
Changelog has been updated in the **2.1.2 WIP** section under **Fixed → Editor & Navigation**.