### PR TITLE
Hotfix accommodation room drink filter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@
 - **Post Connections** - added in a `lsx_to_post_connections_value` allowing you to alter the data before it is returned to the block render function. (e.g strip out the tags).
 - **Itinerary Meta** - added in a `lsx_to_itinerary_field_value` allowing you to alter the data before it is returned to the block render function. (e.g strip out the tags).
 - **FacetWP Indexing** - added in a `lsx_to_facetwp_index_skip_row` to allow the user to skip certain items from being indexed.
+- **Itinerary Room Basis Label** - added in a `lsx_to_room_basis_label` filter to allow 3rd party plugins to override the room basis label on itinerary items.
+- **Itinerary Drinks Basis Label** - added in a `lsx_to_drinks_basis_label` filter to allow 3rd party plugins to override the drinks basis label on itinerary items.
 
 ### Fixed
 

--- a/includes/template-tags/general.php
+++ b/includes/template-tags/general.php
@@ -54,7 +54,7 @@ function lsx_to_itinerary_room_basis( $before = '', $after = '', $echo = true ) 
 	global $tour_itinerary;
 	if ( $tour_itinerary && $tour_itinerary->has_itinerary && ! empty( $tour_itinerary->itinerary ) ) {
 		if ( ! empty( $tour_itinerary->itinerary['room_basis'] ) && 'None' !== $tour_itinerary->itinerary['room_basis'] ) {
-			$label = lsx_to_room_basis_label( $tour_itinerary->itinerary['room_basis'] );
+			$label = apply_filters( 'lsx_to_room_basis_label', lsx_to_room_basis_label( $tour_itinerary->itinerary['room_basis'] ) );
 			if ( $echo ) {
 				echo wp_kses_post( $before . $label . $after );
 			} else {
@@ -91,7 +91,7 @@ function lsx_to_itinerary_drinks_basis( $before = '', $after = '', $echo = true 
 	global $tour_itinerary;
 	if ( $tour_itinerary && $tour_itinerary->has_itinerary && ! empty( $tour_itinerary->itinerary ) ) {
 		if ( ! empty( $tour_itinerary->itinerary['drinks_basis'] ) && 'None' !== $tour_itinerary->itinerary['drinks_basis'] ) {
-			$label = lsx_to_drinks_basis_label( $tour_itinerary->itinerary['drinks_basis'] );
+			$label = apply_filters( 'lsx_to_drinks_basis_label', lsx_to_drinks_basis_label( $tour_itinerary->itinerary['drinks_basis'] ) );
 			if ( $echo ) {
 				echo wp_kses_post( $before . $label . $after );
 			} else {


### PR DESCRIPTION
## Summary

- Added `lsx_to_room_basis_label` filter in `lsx_to_itinerary_room_basis()` — allows 3rd party plugins to override the room basis label on itinerary items
- Added `lsx_to_drinks_basis_label` filter in `lsx_to_itinerary_drinks_basis()` — allows 3rd party plugins to override the drinks basis label on itinerary items
- Updated changelog under the Filters section for v2.1.2

## Test plan

- [x] Confirm room basis label renders correctly (no regression)
- [x] Confirm drinks basis label renders correctly (no regression)
- [x] Verify a filter hooked to `lsx_to_room_basis_label` can override the label
- [x] Verify a filter hooked to `lsx_to_drinks_basis_label` can override the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two new extensibility filters enabling third-party extensions to customise itinerary labels: `lsx_to_room_basis_label` for room basis labels and `lsx_to_drinks_basis_label` for drinks basis labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->