### PR TITLE
fix(ci): skip project-board sync for Dependabot PRs (secrets unavailable)

### DIFF
--- a/.github/workflows/project-meta-sync.yml
+++ b/.github/workflows/project-meta-sync.yml
@@ -17,6 +17,14 @@ env:
 jobs:
   add-and-sync:
     runs-on: ubuntu-latest
+    # Dependabot-triggered workflow runs cannot see this repo's regular Actions
+    # secrets (LS_APP_ID / LS_APP_PRIVATE_KEY included) -- a GitHub security
+    # boundary, not a misconfiguration: a compromised/malicious dependency
+    # update should never be able to mint a GitHub App token. Every step below
+    # needs that token, and there's no board-triage value in placing an
+    # auto-merged version-bump PR on the project board anyway, so skip the
+    # whole job for that actor rather than let it fail on the first step.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Fixes `add-and-sync` failing on every Dependabot-authored PR with:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

## Root cause

This is **not** a missing/misconfigured secret. `LS_APP_ID` and `LS_APP_PRIVATE_KEY` are both correctly set as repository secrets, and the job passes on every non-Dependabot PR (verified on #1329 and #1331 from an unrelated piece of work this session). GitHub deliberately does not expose a repository's regular Actions secrets to workflow runs triggered by Dependabot — a security boundary, not an oversight: a compromised or subtly malicious dependency update should never be able to cause a workflow to mint a privileged GitHub App token. `secrets.LS_APP_ID` simply resolves to empty in that context, which is exactly the error above.

## Fix

Added `if: github.actor != 'dependabot[bot]'` at the job level. Every step in this job depends on the App token from the first step, so there's nothing useful left to run once that's skipped anyway — guarding the whole job is equivalent to guarding the first step, but reads clearer.

**Why not just add the App's private key to the separate Dependabot-secrets store instead** (which does exist for exactly this situation)? There's no board-triage value in placing an auto-merged version-bump PR on the project board — Dependabot PRs get merged or closed, not triaged through Status/Priority/Type like human-authored work. Duplicating a sensitive App credential into a second secret store to support a workflow that has nothing meaningful to do for this actor isn't a trade worth making.

## Verification

- `python3 -m yamllint` on the changed file: same 3 pre-existing line-length warnings as `develop` (confirmed by running yamllint against both versions directly and diffing line numbers — they shift by exactly the 9 lines this change inserts, nothing new).
- YAML parses (`yaml.safe_load`).
