### PR TITLE
chore: drop support for EOL PHP versions, floor at 8.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+#### Requirements
+- **Minimum PHP version raised from 8.0 to 8.2** - PHP 8.0 and 8.1 have both reached end of life (2023-11-26 and 2025-12-31 respectively) and no longer receive security fixes. `Requires PHP` (plugin header, `composer.json`, `readme.txt`) now floors at 8.2, the earliest version still supported - matching what CI already tests against. `phpcs.xml.dist`'s PHPCompatibilityWP `testVersion` raised to match; confirmed no new compatibility findings from the change.
+
 ## [[2.2.0]](https://github.com/lightspeedwp/tour-operator/releases/tag/2.2.0) - 2026-07-30
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "The Tour Operators Plugin provides 3 post types (Accommodations, Destinations and Tours) that are the core of any Tour Operator. Use them to build day-by-day itineraries for tours.",
     "type": "wordpress-plugin",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.2",
         "composer/installers": "^2.3"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "002583fe1d9e1cf9e46858ec4c25ab75",
+    "content-hash": "ead71021b6e1551a59398182e17a099f",
     "packages": [
         {
             "name": "composer/installers",
@@ -2678,7 +2678,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0"
+        "php": ">=8.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -50,11 +50,11 @@
 
     <!-- Minimum supported PHP version -->
     <config name="minimum_supported_wp_version" value="6.0"/>
-    <config name="testVersion" value="8.0-"/>
+    <config name="testVersion" value="8.2-"/>
 
     <!-- Check for cross-version compatibility -->
     <rule ref="PHPCompatibilityWP">
-        <config name="testVersion" value="8.0-"/>
+        <config name="testVersion" value="8.2-"/>
     </rule>
 
     <!-- Text domain check -->

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Plugin URI: https://touroperator.solutions/tour-operator-wordpress-plugin/
 Tags: tour operator, travel, itinerary, tours, destinations, accommodations, tourism
 Requires at least: 6.7
 Tested up to: 7.0
-Requires PHP: 8.0
+Requires PHP: 8.2
 Stable tag: 2.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tour-operator.php
+++ b/tour-operator.php
@@ -9,7 +9,7 @@
  * Version:           2.2
  * Requires at least: 6.7
  * Tested up to:      7.0
- * Requires PHP:      8.0
+ * Requires PHP:      8.2
  * License:           GPLv3 or later
  * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:       tour-operator


### PR DESCRIPTION
## Summary

Raises the declared minimum PHP version from 8.0 to 8.2. PHP 8.0 (EOL 2023-11-26) and PHP 8.1 (EOL 2025-12-31) are both past end of life and receive no security fixes; the plugin header, `composer.json`, and `readme.txt` still claimed to support them.

## Changes

- `tour-operator.php` header: `Requires PHP: 8.0` → `8.2`
- `composer.json`: `"php": ">=8.0"` → `">=8.2"`
- `readme.txt`: `Requires PHP: 8.0` → `8.2`
- `composer.lock`: regenerated (`composer update --lock`) to refresh the platform requirement — no dependency versions changed.
- `phpcs.xml.dist`: both `PHPCompatibilityWP` `testVersion` settings raised from `8.0-` to `8.2-`, so the compatibility sniff actually enforces the floor the plugin now declares instead of a stricter one than what's required.

8.2 was chosen as the floor (not 8.4/8.5) because it's the earliest version still receiving security support as of today, and it's what `.github/workflows/ci.yml` already tests against (`php-version: '8.2'`) — this makes the declared requirement match what's actually exercised, rather than widening or narrowing it further.

## Verification

- `composer test:php` passes.
- `composer phpcs`: diffed the full sniff-type output before and after this change — identical set, zero new findings. Confirms nothing in this codebase relies on anything removed between PHP 8.0 and 8.2, so raising the compatibility floor doesn't surface new violations.
