### PR TITLE
Fix Jest ESM import errors for uuid and marked

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,6 @@ module.exports = {
     setupFiles: ['<rootDir>/tests/js/setup.js'],
     testEnvironment: 'jsdom',
     transformIgnorePatterns: [
-        'node_modules/(?!(@wordpress)/)',
+        'node_modules/(?!(@wordpress|uuid|marked)/)',
     ],
 };


### PR DESCRIPTION
Resolves the SyntaxError: Unexpected token export crashes in npm run test:unit

## Root cause
Jest was failing when tests tried to import @wordpress/blocks, which depends on uuid and marked packages. These packages ship modern ESM builds, but Jest's default configuration ignores all node_modules from Babel transformation, causing SyntaxError when ESM export statements are encountered.

## Solution
Updated jest.config.js transformIgnorePatterns to include uuid and marked modules alongside the existing @wordpress exception. This allows Babel to transform these packages ESM syntax to CommonJS for Jest compatibility.

## Verification
- Before fix: npm run test:unit crashed with SyntaxError on uuid import
- After fix: npm run test:unit passes with 12 tests passing in conditional-registration.test.js