### PR TITLE
Allow CodeRabbit auto-review on fix/1284-featured-query-loop-variations

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -55,6 +55,7 @@ reviews:
       - "2.1-trunk"
       - "main"
       - "master"
+      - "fix/1284-featured-query-loop-variations"
     ignore_title_keywords:
       - "WIP"
       - "DO NOT MERGE"


### PR DESCRIPTION
PR targeting fix/1284-featured-query-loop-variations cannot be auto-reviewed by CodeRabbit because the feature branch is not in the allow-list.

**Current skip message from CodeRabbit on PR #1329:**
> Auto reviews are disabled on base/target branches other than the default branch

**Allow-list before this change:**
- develop
- 2.1-trunk
- main
- master

**Change:**
Added `fix/1284-featured-query-loop-variations` to `.coderabbit.yaml` under `reviews.auto_review.base_branches`.

This enables CodeRabbit to auto-review all PRs targeting this feature branch during active development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automatic code reviews are now triggered for an additional development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->